### PR TITLE
6車線比較 渋滞シミュレーションの刷新とCIテスト追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run simulation tests
+        run: node traffic-simulation.test.js

--- a/index.html
+++ b/index.html
@@ -1,1217 +1,1870 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>6車線比較 渋滞シミュレーション</title>
-    <script src="https://cdn.tailwindcss.com" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" defer></script>
-    <script type="importmap">
-        {
-            "imports": {
-                "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.js",
-                "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/"
-            }
-        }
-    </script>
-    <style>
-        body { margin: 0; overflow: hidden; font-family: 'Inter', sans-serif; background-color: #1a202c; color: #e2e8f0; }
-        #simulationCanvas { display: block; }
-        .panel { background-color: rgba(45, 55, 72, 0.9); border-radius: 0.5rem; padding: 1rem; box-shadow: 0 4px 6px rgba(0,0,0,0.1); }
-        .slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 20px; height: 20px; background: #4299e1; cursor: pointer; border-radius: 50%; }
-        .slider::-moz-range-thumb { width: 20px; height: 20px; background: #4299e1; cursor: pointer; border-radius: 50%; border: none; }
-        #messageBox {
-            position: fixed;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            background-color: rgba(30, 41, 59, 0.95);
-            color: white;
-            padding: 1.5rem 2.5rem;
-            border-radius: 0.5rem;
-            box-shadow: 0 10px 15px rgba(0,0,0,0.2);
-            z-index: 1000;
-            display: none; /* Initially hidden */
-            text-align: center;
-            font-size: 1.1rem;
-        }
-        .custom-scrollbar::-webkit-scrollbar { width: 8px; }
-        .custom-scrollbar::-webkit-scrollbar-track { background: #2d3748; border-radius: 0.25rem; }
-        .custom-scrollbar::-webkit-scrollbar-thumb { background: #4a5568; border-radius: 0.25rem; }
-        .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #718096; }
-        .btn {
-            background-color: #3182ce; color: white; padding: 0.5rem 1rem; border-radius: 0.375rem; font-weight: 600;
-            transition: background-color 0.2s ease-in-out;
-        }
-        .btn:hover { background-color: #2b6cb0; }
-        .btn:active { background-color: #2c5282; }
-        .btn:focus { outline: none; box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5); }
-        #dayNightToggle { 
-            position: absolute;
-            top: 1rem;
-            right: 1rem;
-            width: 44px; 
-            height: 44px;
-            padding: 0.5rem;
-            border-radius: 0.375rem; 
-            background-color: rgba(45, 55, 72, 0.9); 
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            cursor: pointer;
-            z-index: 500; 
-        }
-        #dayNightToggle:hover {
-             background-color: #718096; 
-        }
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>6車線比較 渋滞シミュレーション</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<style>
+  html,body{margin:0;height:100%;overflow:hidden;background:#cfe2ee;
+    transition:background-color .9s ease;
+    font-family:'Hiragino Kaku Gothic ProN','Hiragino Sans','Noto Sans JP','Yu Gothic UI',sans-serif;}
+  #container{position:fixed;inset:0;}
+  canvas{display:block;touch-action:none;}
+
+  /* ---- 高速道路の案内標識風パネル ---- */
+  .sign{
+    background:linear-gradient(180deg,#0d8c4d 0%,#05613b 100%);
+    border:3px solid #fff;border-radius:16px;color:#fff;
+    box-shadow:0 8px 22px rgba(0,30,20,.4), inset 0 1px 0 rgba(255,255,255,.25);
+    transition:filter .9s ease;
+  }
+  .sign.amber{
+    background:linear-gradient(180deg,#d1860c 0%,#965c03 100%);
+    box-shadow:0 8px 22px rgba(40,25,0,.4), inset 0 1px 0 rgba(255,255,255,.25);
+  }
+  /* 夜は標識の照明を落とす(計器盤のような減光) */
+  body.night .sign{filter:brightness(.62) saturate(.92);}
+  @media (prefers-reduced-motion: reduce){
+    html,body,.sign{transition:none;}
+  }
+  .sign.amber .route-badge{color:#965c03;border-color:#965c03;}
+  .panel{position:fixed;z-index:10;padding:12px 14px;user-select:none;-webkit-user-select:none;}
+  #controlPanel{top:12px;left:12px;width:252px;}
+  /* 下部: 2区間を1枚に統合した比較パネル。接合部で緑→琥珀へ滑らかに転換する */
+  #infoPanel{bottom:12px;left:50%;transform:translateX(-50%);width:min(660px,calc(100vw - 24px));
+    background:
+      linear-gradient(180deg, rgba(255,255,255,.10) 0%, rgba(0,0,0,.12) 100%),
+      linear-gradient(90deg, #0d8c4d 0%, #06663d 38%, #a06407 62%, #d1860c 100%);
+    box-shadow:0 8px 22px rgba(0,20,15,.42), inset 0 1px 0 rgba(255,255,255,.25);}
+  #infoPanel .panel-title .route-badge{background:#fff;color:#05613b;border-color:#05613b;}
+  .compare{display:grid;grid-template-columns:1fr 1px 1fr;gap:0 14px;}
+  .compare .seam{background:linear-gradient(180deg,
+    rgba(255,255,255,0) 0%, rgba(255,255,255,.45) 18%, rgba(255,255,255,.45) 82%, rgba(255,255,255,0) 100%);}
+  .side{min-width:0;}
+  /* 王冠はパネル上端の外側左右へ(#infoPanel が位置基準) */
+  .side.left .crown{left:14px;right:auto;}
+  .side.right .crown{right:14px;left:auto;}
+  .side-head{display:flex;align-items:center;gap:7px;font-weight:800;font-size:13px;margin-bottom:6px;}
+  .side.right .route-badge{color:#965c03;border-color:#965c03;}
+  .mini-pair{display:none;margin-left:auto;font-size:12px;font-weight:800;
+    font-variant-numeric:tabular-nums;letter-spacing:.02em;}
+  #infoPanel.collapsed .mini-pair{display:inline-flex;gap:5px;align-items:center;}
+  .mini-pair .mL{color:#c9f5dc;}
+  .mini-pair .mR{color:#ffe1a8;}
+  .mini-pair .sep{opacity:.6;font-weight:600;}
+  .mini-pair .win::before{content:'👑';font-size:10px;margin-right:2px;}
+  .mini-pair .win{text-shadow:0 0 8px rgba(255,213,74,.9);}
+
+  .panel-title{display:flex;align-items:center;gap:8px;font-weight:800;font-size:14px;
+    letter-spacing:.04em;border-bottom:2px solid rgba(255,255,255,.55);padding-bottom:7px;margin-bottom:9px;}
+  .route-badge{display:inline-flex;align-items:center;justify-content:center;
+    min-width:34px;height:22px;padding:0 6px;border-radius:11px;
+    background:#fff;color:#05613b;font-weight:900;font-size:12px;border:2px solid #05613b;
+    box-shadow:0 0 0 2px #fff;}
+  .row{font-size:12.5px;margin:7px 0;line-height:1.45;}
+  .note{font-size:10.5px;opacity:.85;margin-top:6px;line-height:1.5;}
+  .num{font-weight:800;font-variant-numeric:tabular-nums;}
+
+  .score-line{display:flex;align-items:baseline;gap:6px;margin-top:2px;}
+  .score-big{font-size:30px;font-weight:900;font-variant-numeric:tabular-nums;line-height:1;
+    text-shadow:0 2px 4px rgba(0,0,0,.35);}
+  .score-unit{font-size:11px;opacity:.85;}
+  .bar{height:9px;border-radius:5px;background:rgba(255,255,255,.25);overflow:hidden;margin:7px 0 4px;}
+  .bar > div{height:100%;width:0%;border-radius:5px;background:#7CFC9A;
+    transition:width .25s linear, background-color .25s linear;}
+  .status{font-size:12.5px;font-weight:700;}
+  .crown{position:absolute;top:-13px;right:10px;background:#fff;color:#a87900;
+    border:2px solid #ffd54a;border-radius:999px;padding:1px 10px;font-size:11.5px;font-weight:800;
+    box-shadow:0 3px 8px rgba(0,0,0,.25);opacity:0;transform:translateY(4px);transition:all .3s;}
+  .crown.show{opacity:1;transform:translateY(0);}
+
+  input[type=range]{-webkit-appearance:none;appearance:none;width:100%;height:6px;border-radius:3px;
+    background:rgba(255,255,255,.35);outline:none;margin:6px 0 2px;}
+  input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;width:18px;height:18px;
+    border-radius:50%;background:#fff;border:3px solid #ffd54a;cursor:pointer;box-shadow:0 2px 5px rgba(0,0,0,.3);}
+  input[type=range]::-moz-range-thumb{width:16px;height:16px;border-radius:50%;background:#fff;
+    border:3px solid #ffd54a;cursor:pointer;}
+
+  #resetBtn,#nightBtn{width:100%;margin-top:8px;background:#fff;color:#05613b;font-weight:800;font-size:13px;
+    border:none;border-radius:9px;padding:8px 0;cursor:pointer;box-shadow:0 3px 0 #c8d6cd;
+    transition:transform .08s, box-shadow .08s;}
+  #resetBtn:active,#nightBtn:active{transform:translateY(2px);box-shadow:0 1px 0 #c8d6cd;}
+  #nightBtn{background:#15233f;color:#ffe9a8;box-shadow:0 3px 0 #060d1c;}
+  body.night{background:#070b16;}
+  .hint{font-size:10.5px;opacity:.85;margin-top:9px;line-height:1.6;border-top:1px dashed rgba(255,255,255,.4);padding-top:7px;}
+
+  #messageBox{position:fixed;top:46%;left:50%;transform:translate(-50%,-50%);z-index:20;
+    background:rgba(8,40,26,.92);color:#fff;font-weight:700;font-size:15px;
+    padding:14px 26px;border-radius:14px;border:2px solid rgba(255,255,255,.7);
+    opacity:0;pointer-events:none;transition:opacity .35s;}
+  #messageBox.show{opacity:1;}
+  #errorBox{position:fixed;top:12px;left:50%;transform:translateX(-50%);z-index:30;display:none;
+    background:#8c1d2c;color:#fff;font-size:13px;font-weight:700;padding:10px 18px;border-radius:10px;
+    border:2px solid #fff;max-width:80vw;}
+
+  /* ---- 折りたたみ(タイトル行をタップで開閉) ---- */
+  .panel-title{cursor:pointer;}
+  .chev{margin-left:auto;font-size:11px;opacity:.85;transition:transform .25s;}
+  .panel.collapsed .chev{transform:rotate(-90deg);}
+  .panel.collapsed .panel-body{display:none;}
+  .panel.collapsed .panel-title{border-bottom:none;padding-bottom:0;margin-bottom:0;}
+  .mini{display:none;margin-left:6px;font-size:12px;font-weight:800;font-variant-numeric:tabular-nums;}
+  .panel.collapsed .mini{display:inline;}
+  #controlPanel{max-height:calc(100vh - 24px);overflow:auto;}
+
+  /* ---- パラメータ調整室(モーダル) ---- */
+  #paramsBtn{width:100%;margin-top:8px;background:#fff;color:#05613b;font-weight:800;font-size:13px;
+    border:none;border-radius:9px;padding:8px 0;cursor:pointer;box-shadow:0 3px 0 #c8d6cd;
+    transition:transform .08s, box-shadow .08s;}
+  #paramsBtn:active{transform:translateY(2px);box-shadow:0 1px 0 #c8d6cd;}
+  #paramOverlay{position:fixed;inset:0;z-index:40;background:rgba(4,18,12,.55);display:none;
+    align-items:center;justify-content:center;padding:16px;}
+  #paramOverlay.open{display:flex;}
+  #paramModal{width:min(520px,94vw);max-height:84vh;overflow:auto;padding:16px 18px;}
+  #paramModal .panel-title{cursor:default;}
+  #paramClose{margin-left:auto;background:none;border:none;color:#fff;font-size:18px;cursor:pointer;
+    line-height:1;padding:2px 4px;}
+  .fair-note{font-size:11.5px;line-height:1.6;background:rgba(255,255,255,.12);
+    border:1px dashed rgba(255,255,255,.45);border-radius:9px;padding:8px 10px;margin-bottom:10px;}
+  .pgroup{font-size:11px;font-weight:800;letter-spacing:.08em;opacity:.8;margin:12px 0 2px;}
+  .prow{margin:8px 0;}
+  .prow .plabel{display:flex;align-items:baseline;font-size:12.5px;font-weight:700;}
+  .prow .pval{margin-left:auto;font-variant-numeric:tabular-nums;font-weight:800;}
+  .prow .pdesc{font-size:10.5px;opacity:.8;line-height:1.45;}
+  .pactions{display:flex;gap:8px;margin-top:14px;}
+  .pactions button{flex:1;background:#fff;color:#05613b;font-weight:800;font-size:12.5px;
+    border:none;border-radius:9px;padding:8px 0;cursor:pointer;box-shadow:0 3px 0 #c8d6cd;}
+  .pactions button:active{transform:translateY(2px);box-shadow:0 1px 0 #c8d6cd;}
+  .pactions #paramDefaults{background:rgba(255,255,255,.18);color:#fff;box-shadow:0 3px 0 rgba(0,0,0,.3);}
+  .apply-note{font-size:10.5px;opacity:.85;margin-top:7px;line-height:1.5;}
+
+  @media (max-width:700px){
+    #controlPanel{width:min(232px,62vw);padding:10px 11px;}
+    #infoPanel{bottom:8px;width:calc(100vw - 16px);padding:9px 10px;}
+    .compare{gap:0 9px;}
+    .side-head{font-size:11.5px;gap:5px;}
+    .crown{font-size:10px;padding:1px 7px;right:2px;}
+    .panel-title{font-size:12px;}
+    .row{font-size:11px;margin:5px 0;}
+    .score-big{font-size:22px;}
+    .hint,.note{display:none;}
+  }
+  @media (max-height:520px){
+    .hint,.note{display:none;}
+    .row{margin:4px 0;}
+  }
+</style>
 </head>
 <body>
-    <div id="simulationContainer" class="w-screen h-screen relative">
-        <canvas id="simulationCanvas"></canvas>
+<div id="container"></div>
 
-        <button id="dayNightToggle" title="昼夜切り替え">
-        </button>
+<!-- コントロールパネル（左上） -->
+<div id="controlPanel" class="sign panel">
+  <div class="panel-title"><span class="route-badge">E6</span>渋滞シミュレーション<span class="chev">▼</span></div>
+  <div class="panel-body">
+  <div class="row">総車両数: <span class="num" id="vehicleCount">0</span> / <span class="num">200</span></div>
+  <div class="row">
+    車両ペア生成間隔: <span class="num" id="intervalLabel">800</span> ms
+    <input type="range" id="intervalSlider" min="100" max="3000" step="50" value="800">
+  </div>
+  <button id="resetBtn">🔄 リセット</button>
+  <button id="nightBtn">🌙 ナイトモード</button>
+  <button id="paramsBtn">⚙️ パラメータ調整室</button>
+  <div class="hint">🖱 ドラッグ: 視点回転 ／ ホイール: ズーム<br>📱 スワイプ: 回転 ／ ピンチ: ズーム</div>
+  </div>
+</div>
 
-        <div id="controlPanel" class="panel absolute top-4 left-4 w-72 text-sm custom-scrollbar max-h-[calc(100vh-2rem)] overflow-y-auto">
-            <h2 class="text-lg font-semibold text-blue-300 mb-3">コントロールパネル</h2>
-            <div class="mb-2">
-                <label for="totalVehiclesDisplay" class="block">総車両数:</label> <span id="totalVehiclesDisplay">0 / 1000</span> 
-            </div>
-            <div class="mb-3">
-                <label for="spawnInterval" class="block mb-1">車両ペア生成間隔 (ms): <span id="spawnIntervalValue">1000</span>ms</label>
-                <input type="range" id="spawnInterval" min="100" max="3000" value="1000" class="w-full h-2 bg-gray-600 rounded-lg appearance-none cursor-pointer slider">
-            </div>
-            <button id="resetButton" class="w-full btn mb-3">リセット</button>
-            <div class="text-xs text-gray-400">
-                <p>カメラ操作:</p>
-                <p>マウスドラッグ: 回転</p>
-                <p>ホイール: ズーム</p>
-            </div>
+<!-- 左下: 義務あり区間(緑) -->
+<!-- 下部: 2区間の比較パネル(1枚) -->
+<div id="infoPanel" class="sign panel" style="position:fixed;">
+  <div class="panel-title"><span class="route-badge">比</span>渋滞スコア比較
+    <span class="mini-pair"><span class="mL" id="miniLeft">0.0</span><span class="sep">vs</span><span class="mR" id="miniRight">0.0</span></span>
+    <span class="chev">▼</span></div>
+  <div class="panel-body">
+    <div class="compare">
+      <div class="side left">
+        <div class="crown" id="crownLeft">👑 こちらがスムーズ</div>
+        <div class="side-head"><span class="route-badge">義</span>🟢 義務あり</div>
+        <div class="row">車両数: <span class="num" id="countLeft">0</span> 台
+          ／ 平均 <span class="num" id="avgLeft">0</span> km/h</div>
+        <div class="row" style="margin-bottom:0;">渋滞スコア
+          <div class="score-line"><span class="score-big" id="scoreLeft">0.0</span><span class="score-unit">/ 100</span></div>
+          <div class="bar"><div id="barLeft"></div></div>
+          <div class="status" id="statusLeft">🚗💨 スイスイ</div>
         </div>
-
-        <div id="infoPanelLeft" class="panel absolute bottom-4 left-4 w-64 text-sm custom-scrollbar max-h-[calc(50vh-3rem)] overflow-y-auto">
-            <h3 class="text-md font-semibold mb-2 text-green-300">左側 (追いつかれた車両の義務あり)</h3>
-            <p>車両数: <span id="leftVehiclesCount">0</span></p>
-            <p>渋滞スコア: <span id="leftCongestionScore">0.0</span></p>
-            <p>平均車速: <span id="leftAverageSpeed">0.0</span> km/h</p> 
+        <div class="note">※ 速い車が来たら走行車線へ譲り、追い越し後はすぐ戻る</div>
+      </div>
+      <div class="seam"></div>
+      <div class="side right">
+        <div class="crown" id="crownRight">👑 こちらがスムーズ</div>
+        <div class="side-head"><span class="route-badge">自</span>🟠 義務なし</div>
+        <div class="row">車両数: <span class="num" id="countRight">0</span> 台
+          ／ 平均 <span class="num" id="avgRight">0</span> km/h</div>
+        <div class="row" style="margin-bottom:0;">渋滞スコア
+          <div class="score-line"><span class="score-big" id="scoreRight">0.0</span><span class="score-unit">/ 100</span></div>
+          <div class="bar"><div id="barRight"></div></div>
+          <div class="status" id="statusRight">🚗💨 スイスイ</div>
         </div>
-
-        <div id="infoPanelRight" class="panel absolute bottom-4 right-4 w-64 text-sm custom-scrollbar max-h-[calc(50vh-3rem)] overflow-y-auto">
-            <h3 class="text-md font-semibold mb-2 text-red-300">右側 (追いつかれた車両の義務なし)</h3>
-            <p>車両数: <span id="rightVehiclesCount">0</span></p>
-            <p>渋滞スコア: <span id="rightCongestionScore">0.0</span></p>
-            <p>平均車速: <span id="rightAverageSpeed">0.0</span> km/h</p> 
-        </div>
-
-        <div id="messageBox">メッセージがここに表示されます</div>
+        <div class="note">※ 譲る義務がなく、追い越し車線に長居するマイペース派も混在</div>
+      </div>
     </div>
+  </div>
+</div>
 
-    <script type="module">
-        import * as THREE from 'three';
-        import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-        import { Sky } from 'three/addons/objects/Sky.js'; 
+<!-- パラメータ調整室 -->
+<div id="paramOverlay">
+  <div id="paramModal" class="sign">
+    <div class="panel-title"><span class="route-badge">調</span>パラメータ調整室
+      <button id="paramClose" aria-label="閉じる">✕</button></div>
+    <div class="fair-note">🔍 <b>公平性について</b>: ここにある値はすべて<b>両区間のドライバーに共通</b>です。
+      左右の違いは「速い車に追いつかれたら譲るか」というルールだけ。
+      値を自由に動かして、それでも差が出るか確かめてください。</div>
+    <div id="paramList"></div>
+    <div class="pactions">
+      <button id="paramApply">🔄 リセットして適用</button>
+      <button id="paramDefaults">既定値に戻す</button>
+    </div>
+    <div class="apply-note">※ 交通量はすぐに反映されます。ドライバーの性格に関わる値は「リセットして適用」で全車両を作り直すと完全に反映されます。</div>
+  </div>
+</div>
+<div id="messageBox"></div>
+<div id="errorBox"></div>
 
-        // --- グローバル定数と設定 ---
-        const LANE_WIDTH = 3.5;
-        const NUM_LANES_PER_SIDE = 3;
-        const MEDIAN_WIDTH = 4;
-        const ROAD_LENGTH = 800; 
-        const ROAD_START_Z = ROAD_LENGTH / 2; 
-        const ROAD_END_Z = -ROAD_LENGTH / 2; 
-        const MAX_VEHICLES_TOTAL = 1000; 
-        const INITIAL_VEHICLE_PERCENTAGE = 0.075; 
+<!-- ============================================================
+     シミュレーションコア（DOM / THREE 非依存・テスト対象）
+     Node のテスト (traffic-simulation.test.js) はこのブロックを
+     抽出して実行する。描画コードをここに書かないこと。
+     ============================================================ -->
+<script id="sim-core">
+const SimCore = (function(){
+'use strict';
 
-        const FADE_OUT_DURATION = 2.0; 
-        const FADE_OUT_START_DISTANCE_FACTOR = 1.5; 
+/* ---------------- 定数 ---------------- */
+const CONST = {
+  ROAD_HALF: 400,                       // 道路は Z = -400 ～ +400
+  RAMP_Z_TOP: 380,                      // 合流ランプ(加速車線)の始点
+  RAMP_Z_END: 250,                      // 加速車線の終端(ここまでに本線へ合流)
+  DEMAND_FACTOR: 115000,                 // 交通需要(生成間隔あたりの目標台数係数)
+  MAX_VEHICLES: 280,
+  MAX_PER_SECTION: 140,
+  LANE_X: { L: [-3, -7, -11, -15], R: [3, 7, 11, 15] }, // index 0 = 追い越し(中央寄り), 3 = 加速車線
+  LANE_CHANGE_DURATION: 1.4,            // 車線変更所要時間 (s)
+  LANE_CHANGE_WAIT_MAX_DURATION: 2.6,   // 変更待機の上限 (s)
+  LANE_CHANGE_RETRY_COOLDOWN: 2.2,      // キャンセル後の再試行クールダウン (s)
+  OVERTAKE_LANE_RETURN_TIME: 1.8,       // 義務あり区間: 追い越し車線からの復帰判定時間 (s)
+  NO_DUTY_RETURN_TIME_MIN: 9,           // 義務なし区間(一般): 復帰が遅い
+  NO_DUTY_RETURN_TIME_MAX: 16,
+  CAMPER_RETURN_TIME_MIN: 25,           // 義務なし区間(マイペース派): ほぼ戻らない
+  CAMPER_RETURN_TIME_MAX: 35,
+  CAMPER_RATIO: 0.7,                    // 義務なし区間: 譲らない人のうちマイペース派の割合
+  VOLUNTARY_YIELD_RATIO: 0.15,           // 義務なし区間でも自発的に譲る人の割合
+  REF_SPEED: 25,                        // スコア算出の基準速度 (m/s ≒ 90km/h)
+  SCORE_W_SPEED: 0.75,
+  SCORE_W_DENSITY: 0.25,
+  // ---- 渋滞吸収運転モード (mode: 'absorb') ----
+  ABSORBER_RATIO: 0.3,                  // 吸収側区間で渋滞吸収運転をするドライバーの割合
+  ABSORBER_HEADWAY: 3.0,                // 吸収運転が維持したい車間倍率(波を吸うバッファ)
+  ABSORBER_ANTICIPATION: 6.0,           // 下流ペース推定: 減速方向の時定数 (s) — 波に乗らない
+  ABSORBER_RECOVER: 2.0,                // 下流ペース推定: 回復方向の時定数 (s) — 流れ出したら素早く付いていく
+  ABSORBER_PACE_BIAS: 1.0,              // バッファ構築中はペースより少し遅く走る (m/s)
+  HUMAN_GAIN: 0.95,                     // 通常ドライバーの追従ゲイン(強く反応)
+  HUMAN_REACTION: 0.7,                  // 通常ドライバーの知覚遅れ (s) — 渋滞の波の増幅源
+  HUMAN_BRAKE_AMP: 2.6,                 // 通常ドライバーはブレーキを踏みすぎる(波を増幅)
+  HUMAN_ACCEL_LAG: 1.5,                 // 通常ドライバーの再加速の出遅れ (s) — 渋滞先頭の容量低下源
+  SAG_Z_MIN: -10,                       // サグ部(上り坂)の範囲: 無意識の減速で渋滞の種を作る
+  SAG_Z_MAX: 60,
+  SAG_SLOWDOWN: 0.82,                   // サグ部での無意識の減速率(通常ドライバー)
+  SAG_SLOWDOWN_ABSORBER: 0.95,          // 吸収運転は意識して速度を維持する
+  PERTURB_INTERVAL: 45,                 // 渋滞のきっかけ(よそ見ブレーキ)の発生間隔 (s)
+  PERTURB_DURATION: 2.5,                // きっかけブレーキの長さ (s)
+  PERTURB_FACTOR: 0.3,                  // きっかけブレーキの強さ(希望速度比) — 左右ミラーで同時注入
+  ABSORB_DENSITY_FACTOR: 62400          // absorbモードは準安定領域(約13台/車線)に合わせる
+};
 
-        const LANE_CHANGE_DURATION = 1.5;
-        const LANE_CHANGE_WAIT_MAX_DURATION = 2.5; 
-        const LANE_CHANGE_RETRY_COOLDOWN = 1.5; 
-        const OVERTAKE_LANE_RETURN_TIME = 3.0; 
+/* ---------------- 車両タイプ ---------------- */
+const TYPES = {
+  Sedan:     { len: 4.6, w: 1.80, h: 1.42, vmin: 22, vmax: 30, acc: 6.0,
+               colors: [0x3b6fd4, 0xb8bec9, 0x27313f, 0x8c1d2c, 0xe8e6e0] },
+  Truck:     { len: 9.2, w: 2.50, h: 3.50, vmin: 15, vmax: 21, acc: 3.2,
+               colors: [0x2e8b57, 0x4a5568, 0x9aa5b1, 0x7c4a1e] },
+  SportsCar: { len: 4.2, w: 1.90, h: 1.12, vmin: 28, vmax: 38, acc: 9.0,
+               colors: [0xd6452c, 0xf2c200, 0x1450c8, 0xff7a00, 0x111418] },
+  Van:       { len: 5.4, w: 2.00, h: 2.15, vmin: 18, vmax: 25, acc: 4.5,
+               colors: [0xeeeeee, 0x88a0b8, 0x445566, 0x99c2a2] }
+};
+const TYPE_WEIGHTS = [ ['Sedan', 0.46], ['Van', 0.25], ['Truck', 0.11], ['SportsCar', 0.18] ];
 
-        const STREETLIGHT_HEIGHT = 8;
-        const STREETLIGHT_SPACING = 60; // m
+/* ---------------- ユーティリティ ---------------- */
+function clamp(v, a, b){ return v < a ? a : (v > b ? b : v); }
 
-        const VEHICLE_TYPES = { 
-            SEDAN: { name: 'Sedan', color: 0x007bff, length: 4.5, width: 1.8, height: 1.4, minSpeed: 70, maxSpeed: 90, modelScale: [1,1,1], aggression: 0.5 }, 
-            TRUCK: { name: 'Truck', color: 0xff8c00, length: 8.0, width: 2.5, height: 3.5, minSpeed: 70, maxSpeed: 80, modelScale: [1.0, 1.3, 1.6], aggression: 0.2 }, 
-            SPORTS_CAR: { name: 'SportsCar', color: 0xff0000, length: 4.2, width: 1.9, height: 1.2, minSpeed: 80, maxSpeed: 100, modelScale: [0.9,0.9,0.8], aggression: 0.8 }, 
-            VAN: { name: 'Van', color: 0xcccccc, length: 5.5, width: 2.0, height: 2.2, minSpeed: 75, maxSpeed: 85, modelScale: [1.1,1.1,1.2], aggression: 0.4 }
-        };
-        const VEHICLE_TYPE_KEYS = Object.keys(VEHICLE_TYPES);
+// 周回路(リング)の全長。道路の端まで来た車は反対側へ連続的に回り込む。
+// 渋滞の波が境界を継ぎ目なく通過できるため、入口で波が滞留する人工現象が起きない
+const WRAP = CONST.ROAD_HALF * 2 + 16;
+function wrapDelta(d){ // 周回路上の符号付き最短距離 (-WRAP/2, WRAP/2]
+  d = d % WRAP;
+  if (d > WRAP / 2) d -= WRAP;
+  if (d <= -WRAP / 2) d += WRAP;
+  return d;
+}
+function lerp(a, b, t){ return a + (b - a) * t; }
+function smooth(t){ return t * t * (3 - 2 * t); }
+// 乱数 (mulberry32) — テストで再現性を持たせるためシード指定可能
+function createRng(seed){
+  let a = seed >>> 0;
+  return function(){
+    a |= 0; a = a + 0x6D2B79F5 | 0;
+    let t = Math.imul(a ^ a >>> 15, 1 | a);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
 
-        let scene, camera, renderer, controls;
-        let vehicles = [];
-        let clock = new THREE.Clock();
-        let vehicleIdCounter = 0;
+/* ---------------- 車両 ---------------- */
+class Vehicle {
+  constructor(world, section, lane, z, typeName, desiredSpeed){
+    this.world = world;
+    this.section = section;        // 'L' = 義務あり / 'R' = 義務なし
+    this.lane = lane;              // 0 = 追い越し車線
+    this.z = z;
+    this.typeName = typeName;
+    this.type = TYPES[typeName];
+    this.length = this.type.len;
+    this.width = this.type.w;
+    this.initialDesiredSpeed = desiredSpeed;
+    this.desiredSpeed = desiredSpeed;
+    const r = world.rng;
+    this.speed = desiredSpeed * (0.85 + r() * 0.15);
+    this.targetSpeed = desiredSpeed;
+    this.x = CONST.LANE_X[section][lane];
+    this.lc = { state: 'none', from: lane, to: lane, t: 0, hold: 0, checkT: 0 };
+    this.cooldown = 0;
+    this.returnTimer = 0;
+    this.keepLeftTimer = 0;
+    this.noOvertakeT = 0;          // 譲った直後の「我慢」時間(頻繁な変更による乱流防止)
+    this.yieldSlowT = 0;           // 譲り先が塞がっている時に少し減速して後ろに入るための時間
+    this.braking = false;
+    this.emergency = false;
+    this.waiting = false;          // ループ再出現の待機中
+    this.waitT = 0;
+    this.perturbT = 0; // よそ見ブレーキの残り時間(absorbモードでWorldが設定)
+    this._idx = 0;
+    this.color = this.type.colors[Math.floor(r() * this.type.colors.length)];
+    this.isTaxi = (typeName === 'Sedan' && r() < 0.08);
+    if (this.isTaxi) this.color = 0xf5f0dc;
 
-        let sharedGeometries = {};
-        let sharedMaterials = {};
-        let streetLights = []; 
+    // ===== 区間ごとのドライバー気質（モードごとの比較対象の核心） =====
+    this.absorber = false;
+    if (world.mode === 'absorb') {
+      // 渋滞吸収運転モード: 車線変更ルールは両区間とも同一(法令通り)。
+      // 違いは「吸収側(L)の一部ドライバーが車間を広く取り波を吸収する」ことだけ。
+      this.yields = true;
+      this.keepLeft = true;
+      this.camper = false;
+      this.returnTime = CONST.OVERTAKE_LANE_RETURN_TIME;
+      // 吸収運転車は各車線に均等に混ぜる(おおよそ ABSORBER_RATIO の割合で等間隔)
+      if (section === 'L') {
+        world._absRR = world._absRR || [0, 0, 0];
+        const period = Math.max(1, Math.round(1 / CONST.ABSORBER_RATIO));
+        this.absorber = (world._absRR[lane]++ % period) === 1 % period;
+      }
+      // 円周実験と同じく希望速度はほぼ均一にする。車線変更がない世界では
+      // 1台の極端に遅い車が車線全体を支配してしまい、波の比較ができなくなる
+      this.desiredSpeed = 23.5 + r() * 3.0;
+    } else if (section === 'L') {
+      // 義務あり: 譲る・キープレフト・追い越し後はすぐ戻る
+      this.yields = true;
+      this.keepLeft = true;
+      this.camper = false;
+      this.returnTime = CONST.OVERTAKE_LANE_RETURN_TIME;
+    } else {
+      // 義務なし: ルール上の義務はないが、現実には自発的に譲る人も一定割合いる。
+      // 「義務」はこの割合を全員に引き上げるもの — ここがルール比較の核心
+      this.yields = r() < CONST.VOLUNTARY_YIELD_RATIO;
+      this.keepLeft = this.yields && r() < 0.5; // 自発的に譲る人の半数はキープレフトも実践
+      this.camper = !this.yields && r() < CONST.CAMPER_RATIO;
+      this.returnTime = this.camper
+        ? CONST.CAMPER_RETURN_TIME_MIN + r() * (CONST.CAMPER_RETURN_TIME_MAX - CONST.CAMPER_RETURN_TIME_MIN)
+        : CONST.NO_DUTY_RETURN_TIME_MIN + r() * (CONST.NO_DUTY_RETURN_TIME_MAX - CONST.NO_DUTY_RETURN_TIME_MIN);
+    }
 
-        let sky, sun;
-        let isNightMode = false;
-        const dayNightToggleButton = document.getElementById('dayNightToggle');
-        const sunIconSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-sun-fill" viewBox="0 0 16 16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>`;
-        const moonIconSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-moon-stars-fill" viewBox="0 0 16 16"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/><path d="M10.794 3.148a.217.217 0 0 1 .412 0l.387 1.162c.173.518.579.924 1.097 1.097l1.162.387a.217.217 0 0 1 0 .412l-1.162.387a1.73 1.73 0 0 0-1.097 1.097l-.387 1.162a.217.217 0 0 1-.412 0l-.387-1.162A1.73 1.73 0 0 0 9.31 6.593l-1.162-.387a.217.217 0 0 1 0-.412l1.162-.387a1.73 1.73 0 0 0 1.097-1.097zM13.794 1.148a.217.217 0 0 1 .412 0l.387 1.162c.173.518.579.924 1.097 1.097l1.162.387a.217.217 0 0 1 0 .412l-1.162.387a1.73 1.73 0 0 0-1.097 1.097l-.387 1.162a.217.217 0 0 1-.412 0L12.31 3.793a1.73 1.73 0 0 0-1.097-1.097l-1.162-.387a.217.217 0 0 1 0-.412l1.162-.387a1.73 1.73 0 0 0 1.097-1.097z"/></svg>`;
+    // ===== 人間らしさ: ドライバーごとの個性(全モード共通) =====
+    // 実際の渋滞は「前のブレーキを見て減速→後ろも減速…」の連鎖で生まれる。
+    // 知覚の遅れ・反応の強さ・車間の好みに個人差を持たせ、波が自然に発生・増幅する
+    this.percSpeed = this.speed;                            // 知覚している前方車速度(遅れて更新)
+    this.percT = r() * CONST.HUMAN_REACTION;                // 知覚更新タイマー(位相をばらす)
+    this.accT = CONST.HUMAN_ACCEL_LAG;                      // 再加速の出遅れタイマー
+    this.anticip = this.speed;                              // 吸収運転: 下流の平均ペースの推定値
+    this.reaction = CONST.HUMAN_REACTION * (0.7 + r() * 0.8);   // 注意力の個人差
+    this.gainF    = CONST.HUMAN_GAIN * (0.85 + r() * 0.4);      // 車間調整の反応の強さ
+    this.lagF     = CONST.HUMAN_ACCEL_LAG * (0.7 + r() * 0.8);  // 再加速の出遅れの個人差
+    this.headwayF = 0.9 + r() * 0.45;                           // 車間の好み(詰める人/空ける人)
+    this.chainF   = 1.6 + r() * 1.0;                            // ブレーキ灯に身構える距離の係数
+    this.frust    = 0;                                          // 苛立ち(0〜1): 塞がれ続けると上がる
+    this.noise    = 0;                                          // ペダル操作の揺らぎ(現在値)
+    this.hazard   = false;                                      // ハザードランプ点灯中
+    this.hazardT  = 0;                                          // 急ブレーキ後の点灯残り時間
+    this.lampDec  = 0;                                          // 直近フレームの減速度(灯火判定用)
+    this.brakeHold = 0;                                         // ブレーキ灯の最低保持時間
+    this.chainSig = false;                                      // 連鎖反応用の瞬時ブレーキ信号
+    this.lcAversion = 0.7 + r() * 0.6;                          // 車線変更への腰の重さ(個人差)
+    this.slowAheadT = 0;                                        // 遅い車に抑え込まれている時間
+    this.noiseAmp = 0.5 + r() * 0.7;                            // 揺らぎの大きさの個人差
+  }
 
-        const totalVehiclesDisplayElement = document.getElementById('totalVehiclesDisplay'); 
-        const spawnIntervalSliderElement = document.getElementById('spawnInterval');
-        const spawnIntervalValueDisplayElement = document.getElementById('spawnIntervalValue');
-        const resetButtonElement = document.getElementById('resetButton');
-        const leftVehiclesCountDisplayElement = document.getElementById('leftVehiclesCount');
-        const leftCongestionScoreDisplayElement = document.getElementById('leftCongestionScore');
-        const leftAverageSpeedDisplayElement = document.getElementById('leftAverageSpeed'); 
-        const rightVehiclesCountDisplayElement = document.getElementById('rightVehiclesCount');
-        const rightCongestionScoreDisplayElement = document.getElementById('rightCongestionScore');
-        const rightAverageSpeedDisplayElement = document.getElementById('rightAverageSpeed'); 
-        const messageBoxElement = document.getElementById('messageBox');
+  occupies(lane){
+    return lane === this.lane || (this.lc.state !== 'none' && lane === this.lc.to);
+  }
 
-        let simulationRunning = true;
-        let currentSpawnInterval = 1200; 
-        let timeSinceLastSpawn = 0;
-        let lastUiUpdateTime = 0; 
-        const UI_UPDATE_INTERVAL = 200; 
+  // 隣車線にほぼ同速で並走する車両がいるか(車線変更を物理的に塞ぐ「象レース」検知)
+  hasDeadlockAlongside(lane){
+    const arr = this.world._sec[this.section];
+    for (const v of arr) {
+      if (v === this || !v.occupies(lane)) continue;
+      if (Math.abs(wrapDelta(v.z - this.z)) < (this.length + v.length) / 2 + 5 &&
+          Math.abs(v.speed - this.speed) < 1.5) return true;
+    }
+    return false;
+  }
 
-        function initSharedResources() {
-            sharedGeometries = {
-                common: {
-                    light: new THREE.BoxGeometry(0.2, 0.05, 0.05),
-                    blinker: new THREE.BoxGeometry(0.15, 0.1, 0.3),
-                    treeTrunk: new THREE.CylinderGeometry(0.3, 0.4, 6, 8), 
-                    treeLeaves: new THREE.SphereGeometry(2.0, 8, 6),
-                    streetLightPole: new THREE.CylinderGeometry(0.15, 0.2, STREETLIGHT_HEIGHT, 8), 
-                    streetLightLamp: new THREE.SphereGeometry(0.4, 8, 6) 
-                }
-            };
-            sharedMaterials = { 
-                common: {
-                    headLight: new THREE.MeshBasicMaterial({color: 0xffff00, transparent: true }), 
-                    rearLight: new THREE.MeshBasicMaterial({color: 0xff0000, transparent: true }),
-                    blinker: new THREE.MeshBasicMaterial({ color: 0xffA500, transparent: true, opacity: 0.9 }),
-                    treeTrunk: new THREE.MeshStandardMaterial({color: 0x654321, roughness: 0.9}), 
-                    treeLeaves: new THREE.MeshStandardMaterial({color: 0x2E8B57, roughness: 0.8}),
-                    streetLightPole: new THREE.MeshStandardMaterial({color: 0x555555, roughness: 0.7, metalness: 0.3}),
-                    streetLightLamp: new THREE.MeshStandardMaterial({color: 0xffffee, emissive: 0x000000, emissiveIntensity: 0, transparent: true, opacity: 0.7}) 
-                }
-            };
+  // 前方車探索（z昇順インデックスを利用。ahead = z が小さい側。周回路として探索）
+  findAhead(lane){
+    const arr = this.world._sec[this.section];
+    for (let i = this._idx - 1; i >= 0; i--) {
+      const v = arr[i];
+      if (v === this || !v.occupies(lane)) continue;
+      if (v.z >= this.z) continue;
+      return { v, gap: this.z - v.z - (this.length + v.length) / 2 };
+    }
+    // 周回: 自分より手前に誰もいなければ、最も奥(z最大)の同一車線車が前方
+    for (let i = arr.length - 1; i > this._idx; i--) {
+      const v = arr[i];
+      if (v === this || !v.occupies(lane)) continue;
+      return { v, gap: this.z - v.z + WRAP - (this.length + v.length) / 2 };
+    }
+    return null;
+  }
 
-            VEHICLE_TYPE_KEYS.forEach(typeKey => {
-                const type = VEHICLE_TYPES[typeKey];
-                sharedGeometries[typeKey] = {};
-                sharedMaterials[typeKey] = {}; 
+  findBehind(lane){
+    const arr = this.world._sec[this.section];
+    for (let i = this._idx + 1; i < arr.length; i++) {
+      const v = arr[i];
+      if (v === this || !v.occupies(lane)) continue;
+      if (v.z < this.z) continue;
+      return { v, gap: v.z - this.z - (this.length + v.length) / 2 };
+    }
+    // 周回: 自分より奥に誰もいなければ、最も手前(z最小)の車が後続
+    for (let i = 0; i < this._idx; i++) {
+      const v = arr[i];
+      if (v === this || !v.occupies(lane)) continue;
+      return { v, gap: v.z - this.z + WRAP - (this.length + v.length) / 2 };
+    }
+    return null;
+  }
 
-                const bodyGeoFactorZ = (type.name === 'Truck') ? 1.0 : 0.9;
-                const bodyHeightFactor = (type.name === 'Truck') ? 0.6 : 0.7;
-                const scaledBodyHeight = type.height * type.modelScale[1] * bodyHeightFactor;
-                sharedGeometries[typeKey].body = new THREE.BoxGeometry(type.width * type.modelScale[0], scaledBodyHeight, type.length * type.modelScale[2] * bodyGeoFactorZ);
-                sharedMaterials[typeKey].body = new THREE.MeshStandardMaterial({ color: type.color, roughness: 0.5, metalness: 0.3, transparent: true });
-
-                let cabinHeightScaleFactor = 0.6;
-                let cabinLengthScaleFactor = 0.4;
-                if (type.name === 'SportsCar') { cabinHeightScaleFactor = 0.4; cabinLengthScaleFactor = 0.35; }
-                if (type.name === 'Truck') { cabinHeightScaleFactor = 0.6; cabinLengthScaleFactor = 0.25; }
-                const scaledCabinHeight = type.height * type.modelScale[1] * cabinHeightScaleFactor;
-                const scaledCabinLength = type.length * type.modelScale[2] * cabinLengthScaleFactor;
-                sharedGeometries[typeKey].cabin = new THREE.BoxGeometry(type.width * type.modelScale[0] * 0.85, scaledCabinHeight, scaledCabinLength);
-                sharedMaterials[typeKey].cabin = new THREE.MeshStandardMaterial({ color: new THREE.Color(type.color).offsetHSL(0,0,0.1), roughness: 0.4, metalness: 0.2, transparent: true });
-            });
+  // 車線変更先の安全確認: 'safe' | 'hold' | 'danger'
+  // 左方向(譲り・キープレフト)は遅い車線へ移るため、要求マージンをやや緩和する
+  checkLaneSafetyForChange(toLane){
+    let result = 'safe';
+    const relax = toLane > this.lane ? 0.8 : 1.0;
+    const arr = this.world._sec[this.section];
+    for (const v of arr) {
+      if (v === this || !v.occupies(toLane)) continue;
+      const dz = Math.abs(v.z - this.z);
+      if (dz > 90) continue;
+      if (v.z <= this.z) { // 変更先の前方車
+        const gap = this.z - v.z - (this.length + v.length) / 2;
+        if (gap < 1.5) return 'danger';
+        const need = (4 + this.speed * 0.45) * relax;
+        if (gap < need) {
+          if (v.speed >= this.speed + 1) result = 'hold'; // 前方だが自車より速い → 待機
+          else return 'danger';
         }
-
-        function disposeSharedResources() {
-            if (sharedGeometries.common) {
-                Object.values(sharedGeometries.common).forEach(geo => geo.dispose());
-            }
-            if (sharedMaterials.common) {
-                Object.values(sharedMaterials.common).forEach(mat => mat.dispose());
-            }
-            VEHICLE_TYPE_KEYS.forEach(typeKey => {
-                if (sharedGeometries[typeKey]) {
-                    Object.values(sharedGeometries[typeKey]).forEach(geo => geo.dispose());
-                }
-                if (sharedMaterials[typeKey]) {
-                    Object.values(sharedMaterials[typeKey]).forEach(mat => mat.dispose());
-                }
-            });
-            streetLights.forEach(lightGroup => { 
-                lightGroup.children.forEach(child => {
-                    if (child.isLight) { 
-                        child.dispose();
-                    }
-                });
-            });
-            streetLights = [];
-            sharedGeometries = {}; 
-            sharedMaterials = {};
+      } else {             // 変更先の後方車
+        const gap = v.z - this.z - (this.length + v.length) / 2;
+        if (gap < 1.5) return 'danger';
+        const rel = v.speed - this.speed;
+        const need = (4 + Math.max(0, rel) * 2.2 + v.speed * 0.22) * relax;
+        if (gap < need) {
+          if (rel <= -1) result = 'hold';                 // 後方だが自車より遅い → 待機
+          else return 'danger';
         }
+      }
+    }
+    return result;
+  }
 
+  tryLaneChange(toLane){
+    if (toLane < 0 || toLane > 2) return false;
+    if (this.checkLaneSafetyForChange(toLane) !== 'safe') return false;
+    this.lc.state = 'changing';
+    this.lc.from = this.lane;
+    this.lc.to = toLane;
+    this.lc.t = 0;
+    this.lc.hold = 0;
+    this.lc.checkT = 0.15;
+    this.world.stats.changes[this.section]++;
+    return true;
+  }
 
-        class Vehicle {
-            constructor(typeKey, section, initialLaneIndex, keepRightRule) {
-                this.id = vehicleIdCounter++;
-                this.originalTypeKey = typeKey; 
-                this.type = VEHICLE_TYPES[typeKey];
-                this.section = section;
-                this.currentLaneIndex = initialLaneIndex;
-                this.keepRightRule = keepRightRule;
+  cancelLaneChange(){
+    if (this.lc.state !== 'cancel') {
+      this.lc.state = 'cancel';
+      this.world.stats.cancels[this.section]++;
+    }
+  }
 
-                this.length = this.type.length;
-                this.width = this.type.width;
-                this.height = this.type.height;
-                this.aggression = this.type.aggression; 
+  updateLaneChange(dt){
+    const lc = this.lc, C = CONST;
+    if (lc.state === 'none') return;
+    lc.checkT -= dt;
 
-                this.initialDesiredSpeed = THREE.MathUtils.randFloat(this.type.minSpeed, this.type.maxSpeed);
-                this.speed = this.initialDesiredSpeed * THREE.MathUtils.randFloat(0.7, 0.9); 
-                this.targetSpeed = this.initialDesiredSpeed;
-                this.effectiveTargetSpeed = this.initialDesiredSpeed; 
+    if (lc.state === 'changing') {
+      lc.t += dt / C.LANE_CHANGE_DURATION;
+      if (lc.checkT <= 0) {
+        lc.checkT = 0.15;
+        const s = this.checkLaneSafetyForChange(lc.to);
+        if (s === 'danger') { this.cancelLaneChange(); return; }
+        if (s === 'hold' && lc.t < 0.30) { lc.state = 'holding'; lc.hold = 0; }
+      }
+      if (lc.t >= 1) {
+        lc.t = 1;
+        this.lane = lc.to;
+        lc.state = 'none';
+        this.cooldown = 4.0 + this.world.rng() * 5; // 変更直後は当分しない(面倒・疲れる)
+      }
+    } else if (lc.state === 'holding') {
+      lc.hold += dt;
+      if (lc.checkT <= 0) {
+        lc.checkT = 0.15;
+        const s = this.checkLaneSafetyForChange(lc.to);
+        if (s === 'safe') lc.state = 'changing';
+        else if (s === 'danger' || lc.hold > C.LANE_CHANGE_WAIT_MAX_DURATION) this.cancelLaneChange();
+      }
+    } else if (lc.state === 'cancel') {
+      lc.t -= dt / (C.LANE_CHANGE_DURATION * 0.8);
+      if (lc.t <= 0) {
+        lc.t = 0;
+        lc.state = 'none';
+        this.lane = lc.from;
+        this.cooldown = C.LANE_CHANGE_RETRY_COOLDOWN;
+      }
+    }
+  }
 
-                this.mesh = this.createMesh(); 
-                this.mesh.position.y = this.type.height / 2;
-
-                this.boundingBox = new THREE.Box3();
-                this.updateBoundingBox();
-
-                this.isChangingLane = false;
-                this.laneChangeProgress = 0;
-                this.targetLaneIndex = -1;
-                this.laneChangeStartTime = 0;
-                this.laneChangeWaitStartTime = 0;
-                this.laneChangeRetryCooldownTimer = 0;
-                this.laneChangeOriginalX = 0;
-                this.laneChangeTargetX = 0;
-
-                this.timeInOvertakeLane = 0;
-                this.timeSinceLastDecision = 0; 
-                this.decisionInterval = THREE.MathUtils.randFloat(0.3 + (1-this.aggression)*0.5, 0.7 + (1-this.aggression)*0.5);
-
-                this.blinkerState = 'none';
-                this.blinkerTimer = 0;
-                this.blinkerOn = false;
-
-                this.isFadingOut = false;      
-                this.fadeOutProgress = 0;    
-                this.isToBeRemoved = false;    
-                
-                let attempts = 0;
-                let positionOk = false;
-                while(!positionOk && attempts < 50) {
-                    this.mesh.position.z = ROAD_START_Z - this.length - THREE.MathUtils.randFloat(5, 50); 
-                    this.mesh.position.x = this.getLaneCenterX(this.currentLaneIndex);
-                    this.updateBoundingBox();
-                    positionOk = !this.checkInitialOverlap();
-                    attempts++;
-                }
-                 if (!positionOk) {
-                    this.mesh.position.z = ROAD_START_Z - this.length - this.id * (this.length + 10); 
-                    this.updateBoundingBox();
-                }
-                scene.add(this.mesh);
-            }
-            
-            checkInitialOverlap() {
-                for (const other of vehicles) {
-                    if (other === this) continue;
-                    if (this.boundingBox.intersectsBox(other.boundingBox)) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            createMesh() { 
-                const group = new THREE.Group();
-                const typeKeyForSharedResources = this.originalTypeKey; 
-
-                const bodyGeoFactorZ = (this.type.name === 'Truck') ? 1.0 : 0.9;
-                const scaledBodyHeight = this.type.height * this.type.modelScale[1] * ((this.type.name === 'Truck') ? 0.6 : 0.7);
-                
-                const bodyMaterial = sharedMaterials[typeKeyForSharedResources].body.clone();
-                const mainBody = new THREE.Mesh(
-                    sharedGeometries[typeKeyForSharedResources].body, 
-                    bodyMaterial
-                );
-                mainBody.position.y = (-this.type.height / 2) + (scaledBodyHeight / 2);
-                group.add(mainBody);
-
-                let cabinZOffsetFactor = 0.1; 
-                if (this.type.name === 'SportsCar') { cabinZOffsetFactor = 0.05;}
-                if (this.type.name === 'Truck') { 
-                    const cabinLengthScaleFactor = 0.25;
-                    cabinZOffsetFactor = (bodyGeoFactorZ / 2) - (cabinLengthScaleFactor / 2) - 0.02; 
-                }
-                
-                const cabinMaterial = sharedMaterials[typeKeyForSharedResources].cabin.clone();
-                const cabin = new THREE.Mesh(
-                    sharedGeometries[typeKeyForSharedResources].cabin, 
-                    cabinMaterial
-                );
-                const cabinHeightScaleFactor = (this.type.name === 'SportsCar') ? 0.4 : (this.type.name === 'Truck' ? 0.6 : 0.6);
-                const scaledCabinHeight = this.type.height * this.type.modelScale[1] * cabinHeightScaleFactor;
-                const mainBodyTopY = mainBody.position.y + scaledBodyHeight / 2;
-                cabin.position.y = mainBodyTopY + scaledCabinHeight / 2;
-                cabin.position.z = this.type.length * this.type.modelScale[2] * cabinZOffsetFactor;
-                group.add(cabin);
-
-                const lightGeo = sharedGeometries.common.light;
-                const frontLightY = (-this.type.height/2) + this.type.height*0.3;
-                
-                const headLightMaterial = sharedMaterials.common.headLight.clone();
-                headLightMaterial.clonedFromUUID = sharedMaterials.common.headLight.uuid; 
-                const frontLight1 = new THREE.Mesh(lightGeo, headLightMaterial);
-                frontLight1.position.set(this.type.width*0.3, frontLightY, this.type.length/2 * bodyGeoFactorZ * 0.95); 
-                group.add(frontLight1);
-                const frontLight2 = new THREE.Mesh(lightGeo, headLightMaterial); 
-                frontLight2.position.x = -this.type.width*0.3; 
-                frontLight2.position.y = frontLightY;
-                frontLight2.position.z = this.type.length/2 * bodyGeoFactorZ * 0.95;
-                group.add(frontLight2);
-                
-                const rearLightMaterial = sharedMaterials.common.rearLight.clone();
-                rearLightMaterial.clonedFromUUID = sharedMaterials.common.rearLight.uuid; 
-                const backLight1 = new THREE.Mesh(lightGeo, rearLightMaterial);
-                backLight1.position.set(this.type.width*0.3, frontLightY, -this.type.length/2 * bodyGeoFactorZ * 0.95); 
-                group.add(backLight1);
-                const backLight2 = new THREE.Mesh(lightGeo, rearLightMaterial); 
-                backLight2.position.x = -this.type.width*0.3; 
-                backLight2.position.y = frontLightY;
-                backLight2.position.z = -this.type.length/2 * bodyGeoFactorZ * 0.95;
-                group.add(backLight2);
-
-                const blinkerGeo = sharedGeometries.common.blinker;
-                const blinkerMat = sharedMaterials.common.blinker.clone(); 
-                const blinkerY = frontLightY;
-                const blinkerFrontZ = this.type.length / 2 * bodyGeoFactorZ * 0.85;
-                const blinkerRearZ = -this.type.length / 2 * bodyGeoFactorZ * 0.85;
-                const blinkerX = this.type.width / 2 * 0.9;
-
-                this.blinkerLeftFront = new THREE.Mesh(blinkerGeo, blinkerMat); 
-                this.blinkerLeftFront.position.set(-blinkerX, blinkerY, blinkerFrontZ); 
-                this.blinkerLeftFront.visible = false; group.add(this.blinkerLeftFront);
-                
-                this.blinkerRightFront = new THREE.Mesh(blinkerGeo, blinkerMat); 
-                this.blinkerRightFront.position.set(blinkerX, blinkerY, blinkerFrontZ); 
-                this.blinkerRightFront.visible = false; group.add(this.blinkerRightFront);
-                
-                this.blinkerLeftRear = new THREE.Mesh(blinkerGeo, blinkerMat);
-                this.blinkerLeftRear.position.set(-blinkerX, blinkerY, blinkerRearZ); 
-                this.blinkerLeftRear.visible = false; group.add(this.blinkerLeftRear);
-
-                this.blinkerRightRear = new THREE.Mesh(blinkerGeo, blinkerMat);
-                this.blinkerRightRear.position.set(blinkerX, blinkerY, blinkerRearZ); 
-                this.blinkerRightRear.visible = false; group.add(this.blinkerRightRear);
-                
-                group.castShadow = true; group.receiveShadow = true;
-                group.children.forEach(child => { child.castShadow = true; child.receiveShadow = true; });
-                return group;
-            }
-
-            getLaneCenterX(laneIdx) { 
-                if (this.section === 0) {
-                    return -(MEDIAN_WIDTH / 2 + LANE_WIDTH / 2 + laneIdx * LANE_WIDTH);
-                } else {
-                    return (MEDIAN_WIDTH / 2 + LANE_WIDTH / 2 + laneIdx * LANE_WIDTH);
-                }
-            }
-            
-            updateBoundingBox() { 
-                if (!this.mesh) return;
-                this.mesh.updateMatrixWorld(true);
-                this.boundingBox.setFromObject(this.mesh, true);
-            }
-
-            setOpacity(opacity) {
-                if (!this.mesh) return;
-                this.mesh.traverse((object) => {
-                    if (object.isMesh && object.material) {
-                        if (Array.isArray(object.material)) {
-                            object.material.forEach(mat => {
-                                if (mat.transparent) mat.opacity = opacity;
-                            });
-                        } else {
-                           if (object.material.transparent) object.material.opacity = opacity;
-                        }
-                    }
-                });
-            }
-
-            update(deltaTime, allOtherVehicles) {
-                if (this.isToBeRemoved || !this.mesh) return; 
-
-                this.timeSinceLastDecision += deltaTime;
-
-                if (this.laneChangeRetryCooldownTimer > 0) {
-                    this.laneChangeRetryCooldownTimer -= deltaTime;
-                }
-
-                if (this.isChangingLane) {
-                    this.updateLaneChange(deltaTime, allOtherVehicles);
-                } else {
-                    if (this.timeSinceLastDecision > this.decisionInterval) {
-                        this.makeDrivingDecision(deltaTime, allOtherVehicles);
-                        this.timeSinceLastDecision = 0;
-                        this.decisionInterval = THREE.MathUtils.randFloat(0.3 + (1 - this.aggression) * 0.4, 0.7 + (1 - this.aggression) * 0.4); 
-                    }
-                }
-                
-                const { closestVehicle, distance, vehiclesInFrontSameLane } = this.getClosestVehicleInfo(allOtherVehicles);
-                this.adjustSpeedBasedOnTraffic(closestVehicle, distance, vehiclesInFrontSameLane.length, deltaTime);
-
-                this.mesh.position.z -= this.speed * deltaTime;
-                
-                if (this.isFadingOut) {
-                    this.fadeOutProgress += deltaTime / FADE_OUT_DURATION;
-                    const currentOpacity = Math.max(0, 1.0 - this.fadeOutProgress);
-                    this.setOpacity(currentOpacity);
-
-                    if (currentOpacity <= 0 || this.mesh.position.z < ROAD_END_Z - this.length * 3) { 
-                        this.isToBeRemoved = true;
-                        return; 
-                    }
-                } else if (this.mesh.position.z < ROAD_END_Z + this.length * FADE_OUT_START_DISTANCE_FACTOR) { 
-                    this.isFadingOut = true;
-                }
-
-                this.updateBoundingBox();
-
-                if (this.currentLaneIndex === 0 && !this.isChangingLane) { 
-                    this.timeInOvertakeLane += deltaTime;
-                } else {
-                    this.timeInOvertakeLane = 0;
-                }
-
-                if (this.blinkerState !== 'none') {
-                    this.blinkerTimer += deltaTime;
-                    if (this.blinkerTimer > 0.4) {
-                        this.blinkerTimer = 0; this.blinkerOn = !this.blinkerOn;
-                        const targetBlinkers = (this.blinkerState === 'left') ? [this.blinkerLeftFront, this.blinkerLeftRear] : [this.blinkerRightFront, this.blinkerRightRear];
-                        targetBlinkers.forEach(b => { if(b) b.visible = this.blinkerOn; });
-                    }
-                } else {
-                    if (this.blinkerOn) {
-                        [this.blinkerLeftFront, this.blinkerLeftRear, this.blinkerRightFront, this.blinkerRightRear].forEach(b => { if(b) b.visible = false; });
-                        this.blinkerOn = false;
-                    }
-                }
-            }
-            
-            adjustSpeedBasedOnTraffic(frontVehicle, distanceToFront, numVehiclesAhead, deltaTime) {
-                let desiredSpeed = this.initialDesiredSpeed;
-                desiredSpeed *= (1 + (this.aggression - 0.5) * 0.1);
-
-                if (numVehiclesAhead > 3) { 
-                    desiredSpeed *= Math.max(0.6, 1 - numVehiclesAhead * 0.05); 
-                }
-
-                this.effectiveTargetSpeed = desiredSpeed; 
-
-                const safeFollowingDistanceBase = this.length * (1.5 + (1 - this.aggression) * 1.0); 
-                const safeFollowingDistanceDynamic = this.speed * (1.0 + (1 - this.aggression) * 0.5); 
-                const safeDistance = safeFollowingDistanceBase + safeFollowingDistanceDynamic;
-                const emergencyBrakeDistance = this.length * 0.6; 
-
-                if (frontVehicle) {
-                    if (distanceToFront < emergencyBrakeDistance) {
-                        this.speed = Math.max(0, this.speed - 25 * deltaTime); 
-                        this.effectiveTargetSpeed = Math.min(this.effectiveTargetSpeed, frontVehicle.speed * 0.7);
-                    } else if (distanceToFront < safeDistance) {
-                        let targetFollowSpeed = frontVehicle.speed - (1 - this.aggression) * 2; 
-                        targetFollowSpeed = Math.max(0, targetFollowSpeed);
-                        
-                        this.effectiveTargetSpeed = Math.min(this.effectiveTargetSpeed, targetFollowSpeed);
-
-                        if (this.speed > targetFollowSpeed) {
-                            let decelerationRate = 3.0 + this.aggression * 2.0; 
-                            if (distanceToFront < safeDistance * 0.6) decelerationRate *= 1.5; 
-                            this.speed = Math.max(targetFollowSpeed, this.speed - decelerationRate * deltaTime);
-                        } else { 
-                           this.accelerate(deltaTime, frontVehicle.speed);
-                        }
-                    } else {
-                        this.accelerate(deltaTime);
-                    }
-                } else {
-                    this.accelerate(deltaTime);
-                }
-                this.speed = Math.max(0, this.speed);
-                this.speed = Math.min(this.speed, this.type.maxSpeed * 1.1); 
-            }
-            
-            accelerate(deltaTime, capSpeed = Infinity) {
-                const acceleration = (2.0 + this.aggression * 2.0) * deltaTime; 
-                const maxAchievableSpeed = Math.min(this.effectiveTargetSpeed, capSpeed);
-
-                if (this.speed < maxAchievableSpeed) {
-                    this.speed = Math.min(maxAchievableSpeed, this.speed + acceleration);
-                } else if (this.speed > maxAchievableSpeed) { 
-                    this.speed = Math.max(maxAchievableSpeed, this.speed - 1.5 * deltaTime);
-                }
-            }
-
-            getClosestVehicleInfo(allOtherVehicles) {
-                let closestVehicleInLane = null;
-                let minDistanceInLane = Infinity;
-                let vehiclesInFrontSameLane = [];
-
-                for (const other of allOtherVehicles) {
-                    if (other === this || other.section !== this.section || other.isToBeRemoved) continue;
-
-                    if (other.currentLaneIndex === this.currentLaneIndex) {
-                        const distanceZ = this.mesh.position.z - other.mesh.position.z - this.length / 2 - other.length / 2;
-                        if (distanceZ > 0) { 
-                            vehiclesInFrontSameLane.push(other);
-                            if (distanceZ < minDistanceInLane) {
-                                minDistanceInLane = distanceZ;
-                                closestVehicleInLane = other;
-                            }
-                        }
-                    }
-                }
-                return { closestVehicle: closestVehicleInLane, distance: minDistanceInLane, vehiclesInFrontSameLane };
-            }
-
-            makeDrivingDecision(deltaTime, allOtherVehicles) {
-                if (this.isChangingLane || this.laneChangeRetryCooldownTimer > 0 || this.isFadingOut) return;
-                const { closestVehicle: frontVehicleInLane, distance: distanceToFront } = this.getClosestVehicleInfo(allOtherVehicles);
-
-                // 左側車線 (義務あり) の行動
-                if (this.keepRightRule) {
-                    // 1. 後続車に道を譲るか？ (追い越し車線以外にいる場合、より積極的に)
-                    if (this.currentLaneIndex > 0 && this.checkIfShouldYield(allOtherVehicles)) { // 0は一番右(追い越し)
-                        if (this.currentLaneIndex < NUM_LANES_PER_SIDE - 1) { // さらに左に車線がある (indexが大きくなる方向へ)
-                             if (this.initiateLaneChange(this.currentLaneIndex + 1, allOtherVehicles)) return;
-                        }
-                    }
-                    // 2. 追い越し車線や中央車線から、一番左の走行車線(index = NUM_LANES_PER_SIDE - 1)に戻るか？
-                    if (this.currentLaneIndex < NUM_LANES_PER_SIDE - 1 ) { 
-                        const isFrontClearEnough = !frontVehicleInLane || distanceToFront > this.speed * (4.5 - this.aggression * 2.5); 
-                        if (isFrontClearEnough) {
-                            if (this.initiateLaneChange(this.currentLaneIndex + 1, allOtherVehicles)) return;
-                        }
-                    }
-                }
-
-                // 追い越し判断 (左右共通だが、攻撃性の影響で挙動が変わる)
-                let wantsToOvertake = false;
-                const overtakeSpeedDiffThreshold = 3.0 * (1.2 - this.aggression * 0.4); 
-                const overtakeDistanceFactor = 3.0 + this.aggression * 1.0;
-
-                if (frontVehicleInLane) {
-                    const speedDiffToFront = this.effectiveTargetSpeed - frontVehicleInLane.speed;
-                    if (speedDiffToFront > overtakeSpeedDiffThreshold && distanceToFront < (this.speed * overtakeDistanceFactor)) {
-                         wantsToOvertake = true;
-                    }
-                } else if (this.speed < this.effectiveTargetSpeed * 0.9) { 
-                    wantsToOvertake = true; 
-                }
-
-                if (wantsToOvertake && this.currentLaneIndex > 0) { 
-                    if (this.isLaneClearForOvertake(this.currentLaneIndex - 1, allOtherVehicles)) {
-                        if (this.initiateLaneChange(this.currentLaneIndex - 1, allOtherVehicles)) return;
-                    }
-                }
-                
-                // 追い越し車線からの復帰 (一番右のレーン0にいる場合)
-                if (this.currentLaneIndex === 0 && this.timeInOvertakeLane > OVERTAKE_LANE_RETURN_TIME * (1.5 - this.aggression)) {
-                    const canReturn = !frontVehicleInLane || (frontVehicleInLane && frontVehicleInLane.speed >= this.speed - 2);
-                    if (canReturn) {
-                        if (this.currentLaneIndex < NUM_LANES_PER_SIDE - 1) { 
-                             if (this.initiateLaneChange(this.currentLaneIndex + 1, allOtherVehicles)) return;
-                        }
-                    }
-                }
-            }
-            
-            isLaneClearForOvertake(targetLaneIdx, allOtherVehicles) {
-                const lookAheadDistance = this.speed * (4.0 + this.aggression * 2.0); 
-                for (const other of allOtherVehicles) {
-                    if (other.section !== this.section || other.currentLaneIndex !== targetLaneIdx || other.isToBeRemoved) continue;
-                    const distanceZ = this.mesh.position.z - other.mesh.position.z - this.length / 2 - other.length / 2;
-                    if (distanceZ > 0 && distanceZ < lookAheadDistance) { 
-                        if (other.speed < this.speed * (0.6 - this.aggression * 0.2) ) return false; 
-                    }
-                }
-                return true;
-            }
-
-
-            checkIfShouldYield(allOtherVehicles) {
-                if (!this.keepRightRule || this.currentLaneIndex >= NUM_LANES_PER_SIDE - 1) return false; 
-                
-                for (const other of allOtherVehicles) {
-                    if (other === this || other.section !== this.section || other.currentLaneIndex !== this.currentLaneIndex || other.isToBeRemoved) continue;
-                    const distanceZ = other.mesh.position.z - this.mesh.position.z - other.length / 2 - this.length / 2; 
-                    
-                    const yieldDistance = this.speed * (2.5 + (1.0 - this.aggression) * 1.5); 
-                    const yieldSpeedDiff = 1.5 + (1.0 - this.aggression) * 1.5; 
-
-                    if (distanceZ > 0 && distanceZ < yieldDistance) {
-                        if (other.speed > this.speed + yieldSpeedDiff) { 
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            }
-
-            initiateLaneChange(targetLaneIdx, allOtherVehicles) { 
-                if (this.isChangingLane || this.laneChangeRetryCooldownTimer > 0 || this.isFadingOut) return false;
-                if (targetLaneIdx < 0 || targetLaneIdx >= NUM_LANES_PER_SIDE) return false;
-
-                if (this.checkLaneSafetyForChange(targetLaneIdx, allOtherVehicles, true)) {
-                    this.isChangingLane = true; this.targetLaneIndex = targetLaneIdx; this.laneChangeProgress = 0;
-                    this.laneChangeStartTime = clock.getElapsedTime(); this.laneChangeWaitStartTime = 0;
-                    this.laneChangeOriginalX = this.mesh.position.x; this.laneChangeTargetX = this.getLaneCenterX(targetLaneIdx);
-                    this.timeInOvertakeLane = 0;
-                    if (this.targetLaneIndex < this.currentLaneIndex) { this.blinkerState = 'right';} else { this.blinkerState = 'left';}
-                    this.blinkerTimer = 0; this.blinkerOn = true;
-                    const initialBlinkers = (this.blinkerState === 'left') ? [this.blinkerLeftFront, this.blinkerLeftRear] : [this.blinkerRightFront, this.blinkerRightRear];
-                    initialBlinkers.forEach(b => { if(b) b.visible = true; });
-                    return true;
-                }
-                return false;
-            }
-
-            updateLaneChange(deltaTime, allOtherVehicles) { 
-                const safetyStatus = this.checkLaneSafetyForChange(this.targetLaneIndex, allOtherVehicles, false);
-                if (safetyStatus === 'unsafe') { this.cancelLaneChange(); return; }
-                if (safetyStatus === 'wait') {
-                    if (this.laneChangeWaitStartTime === 0) this.laneChangeWaitStartTime = clock.getElapsedTime();
-                    if (clock.getElapsedTime() - this.laneChangeWaitStartTime > LANE_CHANGE_WAIT_MAX_DURATION) { this.cancelLaneChange(); return; }
-                    const { closestVehicle, distance } = this.getClosestVehicleInfo(allOtherVehicles); 
-                    this.adjustSpeedBasedOnTraffic(closestVehicle, distance, 0, deltaTime); 
-                    return;
-                }
-                this.laneChangeWaitStartTime = 0;
-                this.laneChangeProgress = Math.min(1, this.laneChangeProgress + deltaTime / LANE_CHANGE_DURATION);
-                let t = this.laneChangeProgress; let easedProgress = t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
-                this.mesh.position.x = THREE.MathUtils.lerp(this.laneChangeOriginalX, this.laneChangeTargetX, easedProgress);
-                if (this.laneChangeProgress >= 1) { this.completeLaneChange(); }
-            }
-
-            checkLaneSafetyForChange(targetLaneIdx, allOtherVehicles, isInitiation) { 
-                const localAggressionFactor = 1.0 + (this.aggression - 0.5) * 0.4;
-
-                const lookAheadDistance = this.speed * (3.0 + (1 - this.aggression) * 1.0); 
-                const lookBehindDistance = this.speed * (2.0 + (1 - this.aggression) * 1.0);
-                const criticalGapFactor = 1.0 + (1-this.aggression) * 0.5; 
-                const criticalGap = this.length * criticalGapFactor;
-
-                for (const other of allOtherVehicles) {
-                    if (other === this || other.section !== this.section || other.currentLaneIndex !== targetLaneIdx || other.isToBeRemoved) continue;
-                    const otherFront = other.mesh.position.z - other.length / 2; const otherRear = other.mesh.position.z + other.length / 2;
-                    const thisFrontProjected = this.mesh.position.z - this.length / 2; const thisRearProjected = this.mesh.position.z + this.length / 2;
-
-                    if (otherRear > thisFrontProjected - lookAheadDistance && otherFront < thisFrontProjected + criticalGap) { 
-                        const gap = otherRear - thisFrontProjected;
-                        if (gap < criticalGap) return 'unsafe';
-                        if (this.speed > other.speed + (1 * localAggressionFactor) && gap < this.speed * (1.2 / localAggressionFactor)) return 'wait';
-                    }
-                    if (otherFront < thisRearProjected + lookBehindDistance && otherRear > thisRearProjected - criticalGap) { 
-                         const gap = thisRearProjected - otherFront;
-                         if (gap < criticalGap) return 'unsafe';
-                         if (other.speed > this.speed + (1 * localAggressionFactor) && gap < other.speed * (1.2 / localAggressionFactor)) return 'wait';
-                    }
-                }
-                return 'safe';
-            }
-
-            cancelLaneChange() { 
-                this.isChangingLane = false; this.mesh.position.x = this.getLaneCenterX(this.currentLaneIndex);
-                this.laneChangeRetryCooldownTimer = LANE_CHANGE_RETRY_COOLDOWN * (1 + (0.5 - this.aggression) * 0.3); 
-                this.targetLaneIndex = -1; this.blinkerState = 'none';
-            }
-
-            completeLaneChange() { 
-                this.isChangingLane = false; this.currentLaneIndex = this.targetLaneIndex;
-                this.mesh.position.x = this.getLaneCenterX(this.currentLaneIndex);
-                this.targetLaneIndex = -1; this.blinkerState = 'none';
-            }
-            
-            dispose() { 
-                if (this.mesh) {
-                    scene.remove(this.mesh);
-                    this.mesh.traverse((object) => {
-                        if (object.isMesh && object.material) {
-                            if (Array.isArray(object.material)) {
-                                object.material.forEach(mat => mat.dispose());
-                            } else {
-                                object.material.dispose();
-                            }
-                        }
-                    });
-                    this.mesh = null; 
-                }
-            }
+  decide(ahead, dt){
+    // 渋滞吸収運転モードでは車線変更なし(単一車線の追従実験と同じ純粋比較)。
+    // 車線変更があると吸収運転車の広い車間が追い越しで埋められ、比較が濁る。
+    if (this.world.mode === 'absorb') return;
+    // 合流(加速車線): 本線の隙間を見つけ次第、走行車線へ入る。
+    // 終端が近づくほど、現実のドライバー同様に受け入れる隙間を妥協する
+    if (this.lane === 3) {
+      const remain = this.z - CONST.RAMP_Z_END;
+      const press = clamp(1 - remain / 80, 0, 1);
+      const a = this.findAhead(2), b = this.findBehind(2);
+      const okA = !a || a.gap > (this.speed * 0.45 + 4) * (1 - 0.5 * press);
+      const okB = !b || b.gap > Math.max(2.0, (b.v.speed - this.speed) * (1.4 - 0.7 * press) + 2.5);
+      if (okA && okB) {
+        this.lc.state = 'changing';
+        this.lc.from = 3; this.lc.to = 2;
+        this.lc.t = 0; this.lc.hold = 0; this.lc.checkT = 0.15;
+        this.world.stats.changes[this.section]++;
+      }
+      return;
+    }
+    // 渋滞にはまっている時は譲り・復帰・キープレフトの車線変更はしない。
+    // 実際のドライバーも、流れている時にだけ譲り合いの車線変更をする
+    const flowing = this.speed > this.desiredSpeed * 0.6;
+    // (0) 渋滞中の乗り換え: 自分の車線が進まず、隣が明確に流れている/空いている
+    // 時は隣へ移る(全員ではなく苛立っている人ほど。左右では左を優先)。
+    // これがないと「追い越し車線だけ詰まり、隣がガラ空き」の不自然な状態になる
+    if (!flowing && this.frust > 0.5 && this.world.rng() < dt / 3) {
+      const here = this.findAhead(this.lane);
+      const hereGap = here ? here.gap : 999;
+      const hereSp = here ? here.v.speed : this.desiredSpeed;
+      let bestLane = -1, bestScore = 4; // 「明確に良い」時だけ動く
+      for (const dl of [1, -1]) { // 左(走行車線側)から評価 = 同点なら左へ
+        const lane = this.lane + dl;
+        if (lane < 0 || lane > 2) continue;
+        const a = this.findAhead(lane);
+        // 渋滞中の判断は一瞥なので雑(隣の芝生は青く見える): ノイズ込みで評価
+        const score = ((a ? a.gap : 999) - hereGap) * 0.15 +
+                      ((a ? a.v.speed : this.desiredSpeed) - hereSp) +
+                      (this.world.rng() * 2 - 1) * 3;
+        if (score > bestScore) { bestScore = score; bestLane = lane; }
+      }
+      if (bestLane >= 0 && this.tryLaneChange(bestLane)) {
+        this.yieldSlowT = 0.6; // 移った直後は体勢を立て直すため少し緩める
+        return;
+      }
+    }
+    // (0.5) マイペース派(義務なし区間): 走行車線に縛られず、追い越し車線を
+    // 定位置にして自分のペースで巡航する(これが義務なし文化の象徴)
+    if (this.camper && this.lane > 0 && flowing) {
+      this.keepRightT = (this.keepRightT || 0) + dt;
+      if (this.keepRightT > 6 && this.tryLaneChange(this.lane - 1)) {
+        this.keepRightT = 0;
+        return;
+      }
+    }
+    // (1) 「追いつかれた車両の義務」— 義務あり区間のみ: 速い後続車に進路を譲る。
+    // ただし現実のドライバー同様、(a)明確に速い車が来た時だけ、(b)移った先でも
+    // 自分のペースを保てる時だけ譲る(遅いトラックの直後への自己犠牲はしない)
+    if (this.yields && flowing && this.lane < 2) {
+      const behind = this.findBehind(this.lane);
+      if (behind) {
+        const rel = behind.v.speed - this.speed;
+        if (rel > 2.5 && behind.gap < 24 + rel * 4.5) {
+          const t = this.findAhead(this.lane + 1);
+          const okTarget = !t || t.gap > 45 || t.v.speed > this.desiredSpeed - 2;
+          if (okTarget && this.tryLaneChange(this.lane + 1)) {
+            this.world.stats.yields[this.section]++;
+            this.noOvertakeT = 6; // 譲った直後はしばらく追い越しを我慢する
+            return;
+          }
+          // 並走車に塞がれて譲れない(象レース)場合のみ、少し減速して後ろに入る
+          if (okTarget && this.hasDeadlockAlongside(this.lane + 1)) this.yieldSlowT = 1.0;
         }
-
-        function init() {
-            try {
-                initSharedResources(); 
-
-                scene = new THREE.Scene();
-                scene.background = new THREE.Color(0x334455); 
-                scene.fog = new THREE.Fog(0x334455, ROAD_LENGTH * 0.6, ROAD_LENGTH * 2.5); // ★ フォグの far をさらに遠くへ
-
-                const canvas = document.getElementById('simulationCanvas'); 
-                renderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: true }); 
-                renderer.setSize(window.innerWidth, window.innerHeight);
-                renderer.shadowMap.enabled = true;
-                renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-                renderer.toneMapping = THREE.ACESFilmicToneMapping; 
-                renderer.toneMappingExposure = 0.5;
-
-
-                camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, ROAD_LENGTH * 3.0); // ★ カメラの far をフォグに合わせて調整
-                camera.position.set(0, ROAD_LENGTH * 0.12, ROAD_START_Z * 0.4); 
-                
-                controls = new OrbitControls(camera, renderer.domElement); 
-                controls.target.set(0, 0, 0); 
-                controls.enableDamping = true; 
-                controls.dampingFactor = 0.05; 
-                controls.screenSpacePanning = false;
-                controls.minDistance = 30; 
-                controls.maxDistance = ROAD_LENGTH / 1.0; 
-                controls.maxPolarAngle = Math.PI / 2 - 0.01; 
-                controls.update();
-
-                sky = new Sky();
-                sky.scale.setScalar(450000);
-                scene.add(sky);
-
-                sun = new THREE.Vector3();
-
-                const ambientLight = new THREE.AmbientLight(0xffffff, 0.3); 
-                scene.add(ambientLight);
-                scene.userData.ambientLight = ambientLight; 
-
-                const directionalLight = new THREE.DirectionalLight(0xffffff, 0.3); 
-                directionalLight.castShadow = true;
-                directionalLight.shadow.mapSize.width = 2048; 
-                directionalLight.shadow.mapSize.height = 2048;
-                directionalLight.shadow.camera.near = 10; 
-                directionalLight.shadow.camera.far = ROAD_LENGTH * 1.5; // ★ 影の描画範囲も調整
-                directionalLight.shadow.camera.left = -ROAD_LENGTH / 1.5; 
-                directionalLight.shadow.camera.right = ROAD_LENGTH / 1.5;
-                directionalLight.shadow.camera.top = ROAD_LENGTH / 1.5;
-                directionalLight.shadow.camera.bottom = -ROAD_LENGTH / 1.5;
-                directionalLight.shadow.bias = -0.0005;
-                scene.add(directionalLight);
-                scene.userData.directionalLight = directionalLight; 
-
-                updateDayNightMode(false); 
-
-                const groundMaterial = new THREE.MeshStandardMaterial({ color: 0x607D3B, roughness: 0.95, metalness: 0.05 }); 
-                const groundMesh = new THREE.Mesh(new THREE.PlaneGeometry(ROAD_LENGTH * 5, ROAD_LENGTH * 5), groundMaterial); // ★ 地面をさらに大幅に広げる
-                groundMesh.rotation.x = -Math.PI / 2; 
-                groundMesh.position.y = -0.15; 
-                groundMesh.receiveShadow = true;
-                scene.add(groundMesh);
-
-                createRoad(); 
-                createTrees(); 
-                createStreetLights(); 
-
-                spawnIntervalSliderElement.value = currentSpawnInterval; 
-                spawnIntervalValueDisplayElement.textContent = currentSpawnInterval;
-                spawnIntervalSliderElement.addEventListener('input', (event) => {
-                    currentSpawnInterval = parseInt(event.target.value);
-                    spawnIntervalValueDisplayElement.textContent = currentSpawnInterval;
-                });
-                resetButtonElement.addEventListener('click', resetSimulation);
-                dayNightToggleButton.addEventListener('click', toggleDayNightMode); 
-                window.addEventListener('resize', onWindowResize, false);
-
-                spawnInitialVehicles();
-                updateUI();
-                showMessage("シミュレーション開始！ (描画範囲修正版)", 2000);
-            } catch (error) {
-                console.error("初期化エラー:", error.message, error.stack, error); 
-                let errorMessage = "初期化中にエラーが発生しました。";
-                if (error && error.message) {
-                    errorMessage += ` メッセージ: ${error.message}`;
-                }
-                showMessage(`${errorMessage} コンソールを確認してください。`, 10000);
-            }
+      }
+    }
+    // (2) 追い越し — 両区間共通: 遅い前方車がいれば右車線へ。
+    // ただし人間は危険と面倒から車線変更を嫌うので、明確に遅い車に
+    // 「しばらく」抑え込まれて初めて決意する(イライラしているほど早い)
+    if (this.lane > 0) {
+      const blockedNow = ahead && ahead.gap < 18 + this.speed * 0.9 &&
+        (ahead.v.speed < this.desiredSpeed - 2 || this.speed < this.desiredSpeed * 0.88);
+      this.slowAheadT = blockedNow ? this.slowAheadT + dt : 0;
+      let want = this.slowAheadT > 3.0 * this.lcAversion * (1 - 0.6 * this.frust);
+      // 吸収運転車は車線を維持して波を吸収する。よほど遅くない限り追い越さない
+      if (want && this.absorber && this.speed > this.desiredSpeed * 0.55) want = false;
+      // 移った先が今より悪ければ追い越さない(渋滞した追い越し車線へは突っ込まない)
+      if (want && ahead) {
+        const t = this.findAhead(this.lane - 1);
+        if (t && t.v.speed < ahead.v.speed + 1 && t.gap < ahead.gap + 10) want = false;
+      }
+      if (want && this.noOvertakeT > 0) {
+        // 我慢中はよほど詰まらない限り追い越さない(譲り→追い越しの往復を防ぐ)
+        want = !!ahead && ahead.gap < 12 + this.speed * 0.5 && ahead.v.speed < this.desiredSpeed - 5;
+      }
+      if (want && this.tryLaneChange(this.lane - 1)) return;
+    }
+    // (3) 追い越し車線からの復帰 — 両区間共通だが、復帰の早さは気質 (returnTime) で異なる
+    if (this.lane === 0) {
+      const slowAhead = ahead && ahead.gap < 55 && ahead.v.speed < this.desiredSpeed - 1;
+      if (!slowAhead) this.returnTimer += dt; else this.returnTimer = 0;
+      if (this.returnTimer > this.returnTime && flowing) {
+        if (this.tryLaneChange(1)) this.returnTimer = 0;
+        else if (this.section === 'L' && this.hasDeadlockAlongside(1)) this.yieldSlowT = 1.0;
+      }
+      this.keepLeftTimer = 0;
+    } else if (this.keepLeft && flowing && this.lane === 1) {
+      // (4) キープレフト — 義務あり区間のみ: 空いていれば走行車線へ寄る
+      this.returnTimer = 0;
+      // 70m先まで見て、自分のペースで走れる場合だけ走行車線へ寄る(トラック隊列の罠を回避)
+      const leftAhead = this.findAhead(2);
+      const leftClear = !leftAhead || leftAhead.gap > 70 || leftAhead.v.speed > this.desiredSpeed - 1;
+      const notBlocked = !ahead || ahead.gap > 22;
+      if (leftClear && notBlocked) {
+        this.keepLeftTimer += dt;
+        if (this.keepLeftTimer > 2.0 && this.tryLaneChange(2)) {
+          this.keepLeftTimer = 0;
+          this.noOvertakeT = 2;
         }
-        
-        function createTrees() {
-            const treeCount = 100; 
-            const roadOffset = (NUM_LANES_PER_SIDE * LANE_WIDTH) + MEDIAN_WIDTH / 2 + 10; // ★ 樹木の位置を少し道路に近づける
-            // const treeSpacing = ROAD_LENGTH / treeCount * 1.5; 
+      } else {
+        this.keepLeftTimer = 0;
+      }
+    } else {
+      this.returnTimer = 0;
+      this.keepLeftTimer = 0;
+    }
+  }
 
-            for (let i = 0; i < treeCount; i++) {
-                const treeLeft = new THREE.Group();
-                const trunkLeft = new THREE.Mesh(sharedGeometries.common.treeTrunk, sharedMaterials.common.treeTrunk);
-                trunkLeft.position.y = 3; 
-                const leavesLeft = new THREE.Mesh(sharedGeometries.common.treeLeaves, sharedMaterials.common.treeLeaves);
-                leavesLeft.position.y = 6.5; 
-                treeLeft.add(trunkLeft);
-                treeLeft.add(leavesLeft);
-                treeLeft.position.set(
-                    -roadOffset - THREE.MathUtils.randFloatSpread(15), // ★ X方向のばらつきを増やす
-                    0, 
-                    THREE.MathUtils.randFloat(ROAD_END_Z + 50, ROAD_START_Z - 50) // ★ Z方向の配置範囲を調整 (地平線との境界を意識)
-                );
-                treeLeft.rotation.y = Math.random() * Math.PI;
-                treeLeft.scale.setScalar(THREE.MathUtils.randFloat(0.6, 1.0)); // ★ スケールを少し小さめにし、ばらつきも調整
-                treeLeft.castShadow = true; treeLeft.receiveShadow = true;
-                trunkLeft.castShadow = true; leavesLeft.castShadow = true;
-                scene.add(treeLeft);
+  update(dt){
+    const C = CONST;
+    this.cooldown = Math.max(0, this.cooldown - dt);
+    this.noOvertakeT = Math.max(0, this.noOvertakeT - dt);
+    this.yieldSlowT = Math.max(0, this.yieldSlowT - dt);
+    this.updateLaneChange(dt);
 
-                const treeRight = treeLeft.clone(true); 
-                treeRight.position.x = roadOffset + THREE.MathUtils.randFloatSpread(15);
-                treeRight.position.z = THREE.MathUtils.randFloat(ROAD_END_Z + 50, ROAD_START_Z - 50);
-                treeRight.rotation.y = Math.random() * Math.PI;
-                scene.add(treeRight);
-            }
+    // --- 衝突回避: 前方車両追従 ---
+    let ahead = this.findAhead(this.lane);
+    if (this.lc.state !== 'none') {
+      const a2 = this.findAhead(this.lc.to);
+      if (a2 && (!ahead || a2.gap < ahead.gap)) ahead = a2;
+    }
+    this.emergency = false;
+    const isAbsorbMode = this.world.mode === 'absorb';
+    const isHuman = !this.absorber; // 吸収運転車以外は全員「人間」(全モード共通)
+    // 苛立ち: 希望速度よりずっと遅い状態が続くと車間を詰め、反応も荒くなる。
+    // マイペース車に塞がれ続ける側ほど運転が荒れ、渋滞の波が生まれやすくなる
+    if (isHuman) {
+      // 苛立ちは「動けてはいるが遅い」帯域でのみ蓄積する。ノロノロ運転まで
+      // 落ちると諦めて穏やかになる(これが渋滞の自己固定ループを解き、
+      // 渋滞が「解けるべき条件では解ける」ようになる)
+      const ratio = this.speed / this.desiredSpeed;
+      const blocked = ratio < 0.8 && ratio > 0.3;
+      this.frust = clamp(this.frust + (blocked ? dt / 10 : -dt / 5), 0, 1);
+      // ペダル操作の揺らぎ: 人間は一定速度を保てない。この小さな揺らぎが
+      // 長い隊列の中で増幅され、渋滞の波の「種」になる(dt非依存のOU過程)
+      this.noise += -1.2 * this.noise * dt +
+        (this.world.rng() * 2 - 1) * this.noiseAmp * 1.7 * Math.sqrt(dt);
+    }
+    const frust = this.frust;
+    // サグ部(上り坂): 通常ドライバーは無意識に減速し、渋滞の種を作る
+    let desire = this.desiredSpeed;
+    if (isAbsorbMode && this.z > CONST.SAG_Z_MIN && this.z < CONST.SAG_Z_MAX) {
+      desire *= this.absorber ? CONST.SAG_SLOWDOWN_ABSORBER : CONST.SAG_SLOWDOWN;
+    }
+    let ts = this.yieldSlowT > 0 ? Math.max(8, desire - 2.5) : desire;
+    // 加速車線: 終端で止まれる速度に常に制限(合流できなければ端で待つ)
+    if (this.lane === 3 || (this.lc.state !== 'none' && this.lc.from === 3 && this.lc.t < 0.5)) {
+      const remain = Math.max(0, this.z - CONST.RAMP_Z_END);
+      ts = Math.min(ts, Math.sqrt(2 * 3.5 * Math.max(0, remain - 3)));
+    }
+    let reqDec = 0; // 衝突回避に物理的に必要な減速度
+    if (ahead) {
+      // 安全車間サーボ。苛立つほど車間を詰める(詰めた分だけ波に弱くなる)
+      const hwF = this.absorber ? 1 : this.headwayF * (1 - 0.35 * frust);
+      const safeDist = this.length * 1.2 + 2.5 + this.speed * 0.55 * hwF;
+      const emergencyGap = this.length * 0.5 + 1.4;
+      const rel = this.speed - ahead.v.speed;
+      if (rel > 0) {
+        reqDec = (rel * rel) / (2 * Math.max(0.5, ahead.gap - emergencyGap));
+      }
+      // 人間ドライバー: 前方車の速度変化に気づくまで知覚の遅れがある。
+      // この遅れが車間サーボを通じて波を増幅する(渋滞波の標準的な発生機構)。
+      // 物理的に強い減速が必要な場面は下の実値オーバーライドが即座に介入する
+      let aSpeed = ahead.v.speed;
+      if (isHuman) {
+        this.percT -= dt;
+        if (this.percT <= 0) { this.percT = this.reaction; this.percSpeed = ahead.v.speed; }
+        aSpeed = this.percSpeed;
+      }
+      // ウインカーを出して車線変更中の車への反応: 自分と同等以上の速度で入って
+      // くる車には減速は不要(車間は開いていく)。遅い車が目の前に割り込む場合
+      // だけ実ブレーキを強いられる — 渋滞中の乗り換えが渋滞を悪化させる理由
+      const predictable = ahead.v.lc.state !== 'none' &&
+        (ahead.v.speed >= this.speed - 0.5 || ahead.gap > this.speed * 0.5 + 4);
+      const gain = (this.absorber || predictable) ? 0.6 : this.gainF * (1 + 0.5 * frust);
+      if (ahead.gap < emergencyGap) {           // 貫通防止: 緊急ブレーキ
+        ts = 0;
+        this.emergency = true;
+      } else if (ahead.gap < safeDist) {
+        ts = Math.min(ts, Math.max(0, aSpeed + (ahead.gap - safeDist) * gain));
+      } else if (reqDec > 4) {                  // 車間はあるが接近が速すぎる場合も減速
+        ts = Math.min(ts, ahead.v.speed);
+      }
+      // 知覚が遅れていても、物理的に強い減速が必要なら実値で介入(安全は知覚に依存しない)
+      if (!this.emergency && reqDec > 3.5) ts = Math.min(ts, ahead.v.speed);
+      // ===== ブレーキランプ連鎖(実渋滞の主因) =====
+      // 前のブレーキ灯を見たら、車間に余裕があっても身構えてアクセルを抜き、
+      // 前車より少し下まで速度を落とす。この過剰反応が後ろへ行くほど波を増幅し、
+      // 先頭では誰も悪くないのに後方は完全停止する「幽霊渋滞」になる。
+      // ただし自分の方が既に遅い場合(譲りのカットイン等)は身構えるだけで踏まない
+      if (isHuman && !this.emergency && !predictable && ahead.v.chainSig && rel > -0.5 &&
+          ahead.gap < this.speed * this.chainF + 8) {
+        ts = Math.min(ts, Math.max(0, ahead.v.speed - (0.5 + 2.5 * frust)));
+      }
+      // ===== 渋滞吸収運転: 下流の「平均ペース」で定速走行し、波に乗らない =====
+      // 前方の振動(0⇔20km/h等)に追従せず平均速度で淡々と走る。広い車間が
+      // 振動を吸収するバッファになり、後続には滑らかな速度だけが伝わる。
+      if (this.absorber) {
+        // 非対称な平均化: 前方の減速にはすぐ乗らず(波を吸収)、回復には素早く追従する
+        const tau = ahead.v.speed > this.anticip ? CONST.ABSORBER_RECOVER : CONST.ABSORBER_ANTICIPATION;
+        this.anticip += (ahead.v.speed - this.anticip) * Math.min(1, dt / tau);
+        const wantGap = this.length * 1.2 + 2.5 + this.speed * 0.55 * CONST.ABSORBER_HEADWAY;
+        const bias = ahead.gap < wantGap ? CONST.ABSORBER_PACE_BIAS : 0; // バッファ構築
+        ts = Math.min(ts, Math.max(0, this.anticip - bias));
+      }
+    } else if (this.absorber) {
+      this.anticip += (desire - this.anticip) * Math.min(1, dt / CONST.ABSORBER_ANTICIPATION);
+    }
+    this.targetSpeed = ts;
+    // ペダル揺らぎの適用(緊急時を除く)。自由走行では自然な速度の波打ちに、
+    // 密な追従では後続が増幅する小さな乱れになる
+    if (isHuman && !this.emergency) ts = Math.max(0, ts + this.noise);
+    // よそ見ブレーキ(渋滞のきっかけ): 本人の意思とは無関係に減速する
+    if (this.perturbT > 0) {
+      this.perturbT -= dt;
+      ts = Math.min(ts, this.desiredSpeed * CONST.PERTURB_FACTOR);
+      this.targetSpeed = ts;
+    }
+    const diff = ts - this.speed;
+    if (diff > 0) {
+      this.lampDec = 0;
+      if (isHuman && this.accT < this.lagF) {
+        this.accT += dt; // 再加速の出遅れ: 前が動いてもすぐには踏まない(渋滞先頭の容量低下)
+      } else {
+        // 吸収運転は加速も滑らか(波を下流に作らない)
+        const acc = this.absorber ? this.type.acc * 0.6 : this.type.acc;
+        this.speed = Math.min(ts, this.speed + acc * dt);
+      }
+    } else {
+      if (isHuman && diff < -1.0) this.accT = 0; // 減速したら次の再加速はまた出遅れる
+      // 必要減速度に応じてブレーキ強度を可変に。前方車要因がない自発的な減速
+      // (譲りのための速度調整など)はエンジンブレーキ程度に緩やかにする
+      const volDec = isHuman ? 9 : 3.5; // 人間はアクセルオフも雑(波を増幅)
+      const brakeAmp = isHuman ? CONST.HUMAN_BRAKE_AMP : 1.4;   // ブレーキの踏みすぎ
+      const brakeMin = isHuman ? 12 : 9;
+      let dec = this.emergency ? 30 : (reqDec > 0.5 ? clamp(reqDec * brakeAmp, brakeMin, 30) : volDec);
+      if (this.perturbT > 0) dec = Math.max(dec, 9); // よそ見ブレーキは全員同じ強さ(公平)
+      // 急ブレーキを踏んだら後続への警告にハザードを焚く
+      if (dec >= 14 && this.speed > 8) this.hazardT = 2.5;
+      this.lampDec = dec;
+      this.speed = Math.max(Math.max(0, ts), this.speed - dec * dt);
+    }
+    // 連鎖反応(力学)用の瞬時信号は従来どおり
+    this.chainSig = diff < -1.5 || this.emergency;
+    // ブレーキ灯(見た目): 実際にブレーキ相当の減速をしている時だけ点け、点いたら
+    // 最低0.7秒は保持する。人間の踏み替えは秒オーダーで、チラつき(パカパカ)はしない
+    const pressing = this.emergency || (this.lampDec >= 5 && diff < -1.0);
+    this.brakeHold = pressing ? 0.7 : Math.max(0, this.brakeHold - dt);
+    this.braking = pressing || this.brakeHold > 0;
+
+    this.z -= this.speed * dt;
+
+    // --- 意思決定 ---
+    if (this.lc.state === 'none' && this.cooldown <= 0) this.decide(ahead, dt);
+
+    // --- ハザード: 急ブレーキ直後、および停止列の最後尾で後続に知らせる(日本の習慣)。
+    //     後続が近くまで来て減速し終えたら消す ---
+    this.hazardT = Math.max(0, this.hazardT - dt);
+    let queueTail = false;
+    if (this.speed < 2.5) {
+      const b = this.findBehind(this.lane);
+      queueTail = !b || b.gap > 30 || b.v.speed > 6;
+    }
+    this.hazard = queueTail || this.hazardT > 0;
+
+    // --- 周回路: 手前端まで来たら反対側へ連続的に回り込む(波は継ぎ目なく通過) ---
+    if (this.z < -C.ROAD_HALF - 8) this.z += WRAP;
+
+    this.updateX();
+  }
+
+  updateX(){
+    const lx = CONST.LANE_X[this.section], lc = this.lc;
+    if (lc.state !== 'none') {
+      this.x = lerp(lx[lc.from], lx[lc.to], smooth(clamp(lc.t, 0, 1)));
+    } else {
+      this.x = lx[this.lane];
+    }
+  }
+}
+
+/* ---------------- ワールド ---------------- */
+class World {
+  constructor(opts){
+    opts = opts || {};
+    this.rng = opts.rng || Math.random;
+    this.mode = opts.mode || 'rules';   // 'rules' = ルール比較 / 'absorb' = 渋滞吸収運転
+    this.spawnInterval = opts.spawnInterval != null ? opts.spawnInterval : 800;
+    this.vehicles = [];
+    this.spawnAccum = 0;
+    this.time = 0;
+    this._sec = { L: [], R: [] };
+    this.stats = { changes: { L: 0, R: 0 }, yields: { L: 0, R: 0 }, cancels: { L: 0, R: 0 } };
+  }
+
+  pickType(){
+    // absorbモード: 車種を統一(円周実験と同条件)。車長の違いが車線ごとの
+    // 実効密度を準安定帯域から外し、波の比較を濁すのを防ぐ
+    if (this.mode === 'absorb') return 'Sedan';
+    let r = this.rng();
+    for (const [name, w] of TYPE_WEIGHTS) { if ((r -= w) <= 0) return name; }
+    return 'Sedan';
+  }
+
+  // 生成間隔から目標車両数を導出する。
+  // 道路はループ構造で車両が退出しないため、無条件に流入を続けると
+  // どんな間隔でも最終的に飽和渋滞になり左右のルール差が消えてしまう。
+  // そこで「間隔が短い = 交通需要が多い」と解釈し、間隔に応じた密度を維持する。
+  targetCount(){
+    const factor = this.mode === 'absorb' ? CONST.ABSORB_DENSITY_FACTOR : CONST.DEMAND_FACTOR;
+    return clamp(Math.round(factor / this.spawnInterval / 2) * 2, 24, CONST.MAX_VEHICLES);
+  }
+
+  isSpawnClear(section, lane, z, exclude){
+    for (const v of this.vehicles) {
+      if (v === exclude || v.waiting || v.section !== section || !v.occupies(lane)) continue;
+      if (Math.abs(wrapDelta(v.z - z)) < 15 + v.length) return false;
+    }
+    return true;
+  }
+
+  // 指定地点から見た直近前方車の車間と速度(スポーン時の安全速度算出用・周回対応)
+  aheadInfo(section, lane, z, len, exclude){
+    let best = null, bestD = Infinity;
+    for (const v of this.vehicles) {
+      if (v === exclude || v.waiting || v.section !== section || !v.occupies(lane)) continue;
+      let d = z - v.z; // 前方 = z が小さい側。周回を考慮して正の最短距離に
+      d = ((d % WRAP) + WRAP) % WRAP;
+      if (d < 0.001) continue;
+      if (d < bestD) { bestD = d; best = v; }
+    }
+    if (!best) return null;
+    return { gap: bestD - (len + best.length) / 2, speed: best.speed };
+  }
+
+  // 車間内で物理的に止まれる速度に丸める(渋滞の列がスポーン地点まで伸びた場合の追突防止)
+  safeSpawnSpeed(section, lane, z, len, wantSpeed, exclude){
+    const info = this.aheadInfo(section, lane, z, len, exclude);
+    if (!info) return wantSpeed;
+    const vmax = info.speed + Math.sqrt(Math.max(0, 2 * 7 * (info.gap - 4)));
+    return clamp(Math.min(wantSpeed, vmax), 0, wantSpeed);
+  }
+
+  // 車両は左右に1台ずつ、同タイプ・同初期速度のペアで生成される
+  spawnPair(){
+    if (this.vehicles.length >= Math.min(CONST.MAX_VEHICLES, this.targetCount()) - 1) return false;
+    const typeName = this.pickType();
+    const t = TYPES[typeName];
+    let speed = t.vmin + this.rng() * (t.vmax - t.vmin);
+    // 飛ばし屋: ごく一部、流れより明確に速い車がいる(両区間に同条件で出現)
+    if ((typeName === 'Sedan' || typeName === 'SportsCar') && this.rng() < 0.05) {
+      speed = Math.max(speed, 32 + this.rng() * 4); // 希望速度 ≒ 115〜130km/h
+    }
+    // absorbモードでは左右のレーン配置をミラー、かつラウンドロビンで均等にする
+    // (車線変更がないため、各車線を準安定密度の帯域に揃える)
+    // rulesモードは加速車線(レーン3)の始点から流入し、本線へ合流して入る
+    const laneL = this.mode === 'absorb'
+      ? (this._laneRR = ((this._laneRR || 0) + 1) % 3)
+      : 3;
+    const laneR = this.mode === 'absorb' ? laneL : 3;
+    const z = this.mode === 'absorb' ? CONST.ROAD_HALF + t.len : CONST.RAMP_Z_TOP;
+    if (!this.isSpawnClear('L', laneL, z, null) || !this.isSpawnClear('R', laneR, z, null)) return false;
+    const vL = new Vehicle(this, 'L', laneL, z, typeName, speed);
+    const vR = new Vehicle(this, 'R', laneR, z, typeName, speed);
+    vL.speed = this.safeSpawnSpeed('L', laneL, z, vL.length, vL.speed, null);
+    vR.speed = this.safeSpawnSpeed('R', laneR, z, vR.length, vR.speed, null);
+    this.vehicles.push(vL, vR);
+    return true;
+  }
+
+  // 最大車両数の約12%をペアでランダム配置
+  populateInitial(){
+    // 目標台数の7割を最初から本線に配置する(流入は残りをランプから)。
+    // こうしないと混雑側のランプ詰まりが両側の流入を絞り、比較が成立しない
+    const pairs = Math.round(this.targetCount() * 0.7 / 2);
+    for (let i = 0; i < pairs; i++) {
+      for (let tries = 0; tries < 50; tries++) {
+        const typeName = this.pickType();
+        const t = TYPES[typeName];
+        let speed = t.vmin + this.rng() * (t.vmax - t.vmin);
+        if ((typeName === 'Sedan' || typeName === 'SportsCar') && this.rng() < 0.05) {
+          speed = Math.max(speed, 32 + this.rng() * 4); // 飛ばし屋
         }
-        
-        function createStreetLights() {
-            const numLights = Math.floor(ROAD_LENGTH / STREETLIGHT_SPACING);
-            streetLights = []; 
-
-            for (let i = 0; i < numLights; i++) {
-                const zPos = ROAD_START_Z - (i + 0.5) * STREETLIGHT_SPACING;
-
-                const lightGroup = new THREE.Group();
-                
-                const poleMesh = new THREE.Mesh(sharedGeometries.common.streetLightPole, sharedMaterials.common.streetLightPole.clone());
-                poleMesh.castShadow = true;
-                lightGroup.add(poleMesh);
-
-                const lampMesh = new THREE.Mesh(sharedGeometries.common.streetLightLamp, sharedMaterials.common.streetLightLamp.clone());
-                lampMesh.position.y = STREETLIGHT_HEIGHT / 2 + 0.2; 
-                lampMesh.material.name = "streetLightLampInstance"; 
-                lightGroup.add(lampMesh);
-
-                const pointLight = new THREE.PointLight(0xffdcb8, 0, 25, 2); 
-                pointLight.position.set(0, STREETLIGHT_HEIGHT / 2 + 0.1, 0);
-                pointLight.visible = false; 
-                lightGroup.add(pointLight);
-                
-                lightGroup.position.set(0, STREETLIGHT_HEIGHT / 2 -0.1, zPos); 
-                scene.add(lightGroup);
-                streetLights.push(lightGroup); 
-            }
+        const z = -CONST.ROAD_HALF + 25 + this.rng() * (CONST.ROAD_HALF * 2 - 40);
+        const laneL = this.mode === 'absorb'
+          ? (this._laneRR = ((this._laneRR || 0) + 1) % 3)
+          : Math.floor(this.rng() * 3);
+        const laneR = this.mode === 'absorb' ? laneL : Math.floor(this.rng() * 3);
+        if (this.isSpawnClear('L', laneL, z, null) && this.isSpawnClear('R', laneR, z, null)) {
+          this.vehicles.push(new Vehicle(this, 'L', laneL, z, typeName, speed));
+          this.vehicles.push(new Vehicle(this, 'R', laneR, z, typeName, speed));
+          break;
         }
+      }
+    }
+  }
 
+  reset(){
+    this.vehicles.length = 0;
+    this.spawnAccum = 0;
+    this.time = 0;
+    this.populateInitial();
+  }
 
-        function updateDayNightMode(animateTransition = true) {
-            const effectController = {
-                turbidity: isNightMode ? 1.5 : 10, 
-                rayleigh: isNightMode ? 0.05 : 2.5, 
-                mieCoefficient: isNightMode ? 0.002 : 0.005,
-                mieDirectionalG: isNightMode ? 0.98 : 0.7, 
-                elevation: isNightMode ? 2 : 8, 
-                azimuth: 180, 
-                exposure: renderer.toneMappingExposure
-            };
+  _rebuildIndex(){
+    const L = [], R = [];
+    for (const v of this.vehicles) if (!v.waiting) (v.section === 'L' ? L : R).push(v);
+    L.sort((a, b) => a.z - b.z);
+    R.sort((a, b) => a.z - b.z);
+    for (let i = 0; i < L.length; i++) L[i]._idx = i;
+    for (let i = 0; i < R.length; i++) R[i]._idx = i;
+    this._sec.L = L;
+    this._sec.R = R;
+  }
 
-            const uniforms = sky.material.uniforms;
-            uniforms[ 'turbidity' ].value = effectController.turbidity;
-            uniforms[ 'rayleigh' ].value = effectController.rayleigh;
-            uniforms[ 'mieCoefficient' ].value = effectController.mieCoefficient;
-            uniforms[ 'mieDirectionalG' ].value = effectController.mieDirectionalG;
-
-            const phi = THREE.MathUtils.degToRad( 90 - effectController.elevation );
-            const theta = THREE.MathUtils.degToRad( effectController.azimuth );
-            sun.setFromSphericalCoords( 1, phi, theta );
-            uniforms[ 'sunPosition' ].value.copy( sun );
-            
-            if (scene.fog) { 
-                if (isNightMode) {
-                    scene.userData.ambientLight.intensity = 0.45; 
-                    scene.userData.directionalLight.intensity = 0.55; 
-                    scene.userData.directionalLight.color.setHex(0x7070cc); 
-                    scene.fog.color.setHex(0x020207); 
-                    scene.fog.near = ROAD_LENGTH * 0.1; 
-                    scene.fog.far = ROAD_LENGTH * 0.6; 
-                    dayNightToggleButton.innerHTML = sunIconSVG;
-                    dayNightToggleButton.title = "昼モードに切り替え";
-                    renderer.toneMappingExposure = 0.4; 
-                } else {
-                    scene.userData.ambientLight.intensity = 0.7;
-                    scene.userData.directionalLight.intensity = 0.9;
-                    scene.userData.directionalLight.color.setHex(0xffffff);
-                    scene.fog.color.setHex(0x87ceeb); 
-                    scene.fog.near = ROAD_LENGTH * 0.6; 
-                    scene.fog.far = ROAD_LENGTH * 1.8; 
-                    dayNightToggleButton.innerHTML = moonIconSVG;
-                    dayNightToggleButton.title = "夜モードに切り替え";
-                    renderer.toneMappingExposure = 0.5;
-                }
-            }
-            vehicles.forEach(v => {
-                if (v.mesh) {
-                    v.mesh.traverse(child => {
-                        if (child.isMesh && child.material && child.material.isMaterial) { 
-                            if (child.material.clonedFromUUID === sharedMaterials.common.headLight.uuid) { 
-                                if (!(child.material.emissive instanceof THREE.Color)) { 
-                                    child.material.emissive = new THREE.Color(0x000000);
-                                }
-                                child.material.emissive.setHex(isNightMode ? 0xffffaa : 0x000000);
-                                child.material.color.setHex(isNightMode ? 0xffffee : 0xffff00); 
-                            }
-                            if (child.material.clonedFromUUID === sharedMaterials.common.rearLight.uuid) {
-                                if (!(child.material.emissive instanceof THREE.Color)) { 
-                                    child.material.emissive = new THREE.Color(0x000000);
-                                }
-                                child.material.emissive.setHex(isNightMode ? 0xff8888 : 0x000000);
-                                child.material.color.setHex(isNightMode ? 0xff6666 : 0xff0000);
-                            }
-                        }
-                    });
-                }
-            });
-
-            streetLights.forEach(lightGroup => {
-                const pointLight = lightGroup.children.find(child => child.isPointLight);
-                const lampMesh = lightGroup.children.find(child => child.material && child.material.name === "streetLightLampInstance");
-                if (pointLight) {
-                    pointLight.visible = isNightMode;
-                    pointLight.intensity = isNightMode ? 1.2 : 0; 
-                }
-                if (lampMesh) {
-                    lampMesh.material.emissiveIntensity = isNightMode ? 1.5 : 0; 
-                    if(isNightMode) lampMesh.material.emissive.setHex(0xffdcb8); else lampMesh.material.emissive.setHex(0x000000);
-                }
-            });
+  step(dt){
+    this.time += dt;
+    this.spawnAccum += dt * 1000;
+    if (this.spawnAccum >= this.spawnInterval) {
+      if (this.spawnPair()) this.spawnAccum = 0;
+      else this.spawnAccum = Math.max(0, this.spawnInterval - 200); // 塞がっていれば少し待つ
+    }
+    // absorbモード: 渋滞のきっかけ(よそ見ブレーキ)を左右のミラーペアに同時注入。
+    // 同じきっかけが、通常側では波に育ち、吸収側では吸収されて消えるのを比較する
+    if (this.mode === 'absorb') {
+      if (this.perturbT == null) this.perturbT = 15;
+      this.perturbT -= dt;
+      if (this.perturbT <= 0) {
+        this.perturbT = CONST.PERTURB_INTERVAL;
+        const pairs = [];
+        for (let i = 0; i + 1 < this.vehicles.length; i += 2) {
+          const a = this.vehicles[i], b = this.vehicles[i + 1];
+          if (a.section === 'L' && b.section === 'R' && !a.waiting && !b.waiting) pairs.push([a, b]);
         }
-
-        function toggleDayNightMode() {
-            isNightMode = !isNightMode;
-            updateDayNightMode();
+        if (pairs.length) {
+          const [a, b] = pairs[Math.floor(this.rng() * pairs.length)];
+          a.perturbT = CONST.PERTURB_DURATION;
+          b.perturbT = CONST.PERTURB_DURATION;
         }
+      }
+    }
+    this._rebuildIndex();
+    for (const v of this.vehicles) v.update(dt);
+  }
 
+  // 渋滞スコア: 平均速度(重み75%) + 密度(重み25%) → 0～100
+  computeSection(section){
+    let n = 0, sum = 0;
+    for (const v of this.vehicles) {
+      if (v.section !== section) continue;
+      n++;
+      // 待機車 = 入口まで伸びた渋滞最後尾の見えない延長。速度0として計上しないと
+      // 「渋滞がひどい区間ほど待機に逃げてスコアが良くなる」という嘘になる
+      sum += v.waiting ? 0 : v.speed;
+    }
+    if (n === 0) return { n: 0, avg: 0, score: 0 };
+    const avg = sum / n;
+    const speedFactor = clamp(1 - avg / CONST.REF_SPEED, 0, 1);
+    const densityFactor = clamp(n / CONST.MAX_PER_SECTION, 0, 1);
+    return { n, avg, score: (CONST.SCORE_W_SPEED * speedFactor + CONST.SCORE_W_DENSITY * densityFactor) * 100 };
+  }
+}
 
-        function createRoad() { 
-            const totalRoadWidth = (LANE_WIDTH * NUM_LANES_PER_SIDE * 2) + MEDIAN_WIDTH;
-            const roadGeometry = new THREE.PlaneGeometry(totalRoadWidth, ROAD_LENGTH); 
-            const roadMaterial = new THREE.MeshStandardMaterial({ color: 0x4a4a4a, roughness: 0.8, metalness: 0.1 }); 
-            const roadMesh = new THREE.Mesh(roadGeometry, roadMaterial);
-            roadMesh.rotation.x = -Math.PI / 2; roadMesh.receiveShadow = true;
-            scene.add(roadMesh);
+return { CONST, TYPES, Vehicle, World, createRng, clamp, lerp, smooth };
+})();
+if (typeof globalThis !== 'undefined') globalThis.SimCore = SimCore;
+</script>
 
-            const medianGeometry = new THREE.BoxGeometry(MEDIAN_WIDTH, 0.5, ROAD_LENGTH); 
-            const medianMaterial = new THREE.MeshStandardMaterial({ color: 0x38a169 });
-            const medianMesh = new THREE.Mesh(medianGeometry, medianMaterial);
-            medianMesh.position.y = 0.25; medianMesh.receiveShadow = true; medianMesh.castShadow = true;
-            scene.add(medianMesh);
+<!-- ============================================================
+     描画・UI（ブラウザ専用）
+     ============================================================ -->
+<script id="renderer">
+(function(){
+'use strict';
 
-            const lineMaterial = new THREE.LineBasicMaterial({ color: 0xffffff});
-            const dashedLineMaterial = new THREE.LineDashedMaterial({ color: 0xffffff, dashSize: 5, gapSize: 3, scale:1 }); 
-            
-            for (let side = 0; side < 2; side++) {
-                const sideMultiplier = (side === 0) ? -1 : 1;
-                let currentXEdge = sideMultiplier * (MEDIAN_WIDTH / 2 + LANE_WIDTH * NUM_LANES_PER_SIDE);
-                let pointsEdge = [ new THREE.Vector3(currentXEdge, 0.01, ROAD_START_Z), new THREE.Vector3(currentXEdge, 0.01, ROAD_END_Z) ];
-                let lineEdge = new THREE.Line(new THREE.BufferGeometry().setFromPoints(pointsEdge), lineMaterial);
-                scene.add(lineEdge);
+/* ================= エラーハンドリング ================= */
+const errorBox = document.getElementById('errorBox');
+function showError(msg){
+  console.error('[Simulation Error]', msg);
+  errorBox.textContent = '⚠ エラーが発生しました: ' + msg;
+  errorBox.style.display = 'block';
+}
+window.addEventListener('error', function(e){ showError(e.message); });
 
-                for (let i = 0; i < NUM_LANES_PER_SIDE; i++) {
-                    let currentX = sideMultiplier * (MEDIAN_WIDTH / 2 + LANE_WIDTH * i);
-                     if (i < NUM_LANES_PER_SIDE) {
-                        let points = [ new THREE.Vector3(currentX, 0.01, ROAD_START_Z), new THREE.Vector3(currentX, 0.01, ROAD_END_Z) ];
-                        let mat = (i === 0) ? lineMaterial : dashedLineMaterial; 
-                        let line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(points), mat);
-                        if (mat === dashedLineMaterial) line.computeLineDistances();
-                        scene.add(line);
-                    }
-                }
-            }
-        }
-        
-        function spawnInitialVehicles() { 
-            const numToSpawn = Math.floor(MAX_VEHICLES_TOTAL * INITIAL_VEHICLE_PERCENTAGE);
-            for (let i = 0; i < numToSpawn / 2; i++) {
-                 if (vehicles.length < MAX_VEHICLES_TOTAL -1) { spawnVehiclePair(); }
-                 else if (vehicles.length < MAX_VEHICLES_TOTAL) { spawnVehiclePair(); } 
-            }
-        }
+const C = SimCore.CONST;
+const clamp = SimCore.clamp;
+const ROAD_HALF = C.ROAD_HALF;
 
-        function spawnVehiclePair() { 
-            if (vehicles.length >= MAX_VEHICLES_TOTAL) return; 
-            const randomTypeKey = VEHICLE_TYPE_KEYS[Math.floor(Math.random() * VEHICLE_TYPE_KEYS.length)];
-            const randomLaneLeft = Math.floor(Math.random() * NUM_LANES_PER_SIDE);
-            const randomLaneRight = Math.floor(Math.random() * NUM_LANES_PER_SIDE);
-            
-            if (vehicles.length < MAX_VEHICLES_TOTAL) {
-                const vehicleLeft = new Vehicle(randomTypeKey, 0, randomLaneLeft, true);
-                vehicleLeft.mesh.position.z = ROAD_START_Z - vehicleLeft.length - THREE.MathUtils.randFloat(5, 50); 
-                let attemptsL = 0;
-                while (attemptsL < 10 && checkOverlapWithExisting(vehicleLeft)) {
-                    vehicleLeft.mesh.position.z -= vehicleLeft.length + 2; 
-                    vehicleLeft.updateBoundingBox();
-                    attemptsL++;
-                }
-                vehicles.push(vehicleLeft);
-            }
+/* ================= Three.js セットアップ ================= */
+let scene, camera, renderer;
+const SKY = 0xcfe2ee;
+try {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(SKY);
+  scene.fog = new THREE.Fog(SKY, 140, 420); // 遠景処理: 遠方が背景に溶け込む
 
-            if (vehicles.length < MAX_VEHICLES_TOTAL) {
-                const vehicleRight = new Vehicle(randomTypeKey, 1, randomLaneRight, false);
-                vehicleRight.mesh.position.z = ROAD_START_Z - vehicleRight.length - THREE.MathUtils.randFloat(5, 50);
-                let attemptsR = 0;
-                while (attemptsR < 10 && checkOverlapWithExisting(vehicleRight)) {
-                    vehicleRight.mesh.position.z -= vehicleRight.length + 2;
-                    vehicleRight.updateBoundingBox();
-                    attemptsR++;
-                }
-                 vehicles.push(vehicleRight);
-            }
-        }
-        
-        function checkOverlapWithExisting(newVehicle) { 
-            for (const existingVehicle of vehicles) {
-                if (existingVehicle === newVehicle || existingVehicle.isToBeRemoved) continue;
-                if (newVehicle.boundingBox.intersectsBox(existingVehicle.boundingBox)) { return true; }
-            }
-            return false;
-        }
+  camera = new THREE.PerspectiveCamera(55, innerWidth / innerHeight, 0.5, 1200);
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+  renderer.setSize(innerWidth, innerHeight);
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  document.getElementById('container').appendChild(renderer.domElement);
+} catch (e) { showError('WebGLの初期化に失敗しました。' + e.message); throw e; }
 
-        function resetSimulation() { 
-            showMessage("シミュレーションをリセットします...", 1500);
-            simulationRunning = false;
-            
-            vehicles.forEach(v => v.dispose()); 
-            vehicles = []; 
-            vehicleIdCounter = 0;
-            
-            disposeSharedResources(); 
-            initSharedResources();
+/* ---- ライティング ---- */
+const hemi = new THREE.HemisphereLight(0xeaf4ff, 0x55694f, 0.85);
+scene.add(hemi);
+const sun = new THREE.DirectionalLight(0xfff3df, 0.95);
 
-            streetLights.forEach(lightGroup => {
-                lightGroup.children.forEach(child => {
-                    if(child.isLight) child.dispose(); 
-                });
-                scene.remove(lightGroup);
-            });
-            streetLights = []; 
-            createStreetLights(); 
+/* ---- 昼夜テーマ(nightMixで連続補間) ---- */
+const ENV = {
+  day:   { bg: 0xeef4f6, fogColor: 0xdfeef5, fogNear: 140, fogFar: 420,
+           hemiSky: 0xeaf4ff, hemiGround: 0x55694f, hemiInt: 0.85,
+           sunColor: 0xfff3df, sunInt: 0.95,
+           headEmissive: 0x6b6346, glassEmissive: 0x000000,
+           tailIdle: 0x4a0b0b, lampEmissive: 0x000000, delin: 0x9aa3ad },
+  night: { bg: 0x141d33, fogColor: 0x161f36, fogNear: 100, fogFar: 360,
+           hemiSky: 0x32415f, hemiGround: 0x0a100e, hemiInt: 0.32,
+           sunColor: 0x9fb6e8, sunInt: 0.30,
+           headEmissive: 0xffe9a8, glassEmissive: 0x332912,
+           tailIdle: 0x7a1212, lampEmissive: 0xffc36b, delin: 0xffb054 }
+};
+let isNight = false;
+sun.position.set(70, 130, 50);
+sun.castShadow = true;
+sun.shadow.mapSize.set(2048, 2048);
+sun.shadow.camera.left = -170; sun.shadow.camera.right = 170;
+sun.shadow.camera.top = 220;  sun.shadow.camera.bottom = -220;
+sun.shadow.camera.near = 20;  sun.shadow.camera.far = 500;
+sun.shadow.bias = -0.0006;
+scene.add(sun);
 
+/* ---- 地面（背景の透け防止のため広く・低く配置） ---- */
+const ground = new THREE.Mesh(
+  new THREE.PlaneGeometry(1600, 1600),
+  new THREE.MeshLambertMaterial({ color: 0x7d9a6a })
+);
+ground.rotation.x = -Math.PI / 2;
+ground.position.y = -0.18;
+ground.receiveShadow = true;
+scene.add(ground);
 
-            currentSpawnInterval = 1200; 
-            spawnIntervalSliderElement.value = currentSpawnInterval; 
-            spawnIntervalValueDisplayElement.textContent = currentSpawnInterval;
-            timeSinceLastSpawn = 0;
-            
-            isNightMode = false; 
-            updateDayNightMode(false); 
+/* ---- 区間テーマカラー(どの角度から見ても区別できるように) ---- */
+const SECTION_THEME = {
+  L: { road: 0x3a463f, strip: 0x1fb46a, signBg: '#0d8c4d', title: '義務あり', sub: 'ゆずりあい区間' },
+  R: { road: 0x4a4238, strip: 0xf2a32b, signBg: '#c17a08', title: '義務なし', sub: 'マイペース区間' }
+};
 
-            spawnInitialVehicles(); 
-            updateUI();
-            simulationRunning = true;
-        }
+/* ---- 道路(区間ごとに色味を変える) ---- */
+for (const [sec, cx] of [['L', -7], ['R', 7]]) {
+  const road = new THREE.Mesh(
+    new THREE.BoxGeometry(13.2, 0.12, ROAD_HALF * 2),
+    new THREE.MeshLambertMaterial({ color: SECTION_THEME[sec].road })
+  );
+  road.position.set(cx, -0.06, 0);
+  road.receiveShadow = true;
+  scene.add(road);
+  // 外側の路肩ライン(テーマカラー)
+  const strip = new THREE.Mesh(
+    new THREE.BoxGeometry(0.7, 0.06, ROAD_HALF * 2),
+    new THREE.MeshBasicMaterial({ color: SECTION_THEME[sec].strip })
+  );
+  strip.position.set(cx < 0 ? -14.1 : 14.1, -0.03, 0);
+  scene.add(strip);
+}
 
-        function onWindowResize() { 
-            camera.aspect = window.innerWidth / window.innerHeight; camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
-        }
-        
-        function showMessage(message, duration = 3000) { 
-            messageBoxElement.textContent = message; messageBoxElement.style.display = 'block';
-            setTimeout(() => { messageBoxElement.style.display = 'none'; }, duration);
-        }
+/* ---- 車線マーキング ---- */
+const lineMatW = new THREE.MeshBasicMaterial({ color: 0xf2f2f2 });
+function solidLine(x){
+  const m = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.02, ROAD_HALF * 2), lineMatW);
+  m.position.set(x, 0.01, 0);
+  scene.add(m);
+}
+function dashedLine(x){
+  const geo = new THREE.BoxGeometry(0.15, 0.02, 4);
+  for (let z = -ROAD_HALF + 2; z < ROAD_HALF; z += 12) {
+    const d = new THREE.Mesh(geo, lineMatW);
+    d.position.set(x, 0.01, z);
+    d.matrixAutoUpdate = false; d.updateMatrix();
+    scene.add(d);
+  }
+}
+[-1, -13, 1, 13].forEach(solidLine);
+[-5, -9, 5, 9].forEach(dashedLine);
 
-        function calculateCongestionScore(vehicleList, numLanes) { 
-            if (vehicleList.length === 0) return { score: "0.0", averageSpeed: 0 }; 
-            let totalSpeed = 0;
-            vehicleList.forEach(v => totalSpeed += v.speed);
-            const averageSpeedMs = totalSpeed / vehicleList.length; 
-            
-            let avgDesiredMaxSpeed = 0;
-            VEHICLE_TYPE_KEYS.forEach(key => avgDesiredMaxSpeed += VEHICLE_TYPES[key].maxSpeed);
-            avgDesiredMaxSpeed /= VEHICLE_TYPE_KEYS.length;
+/* ---- 合流ランプ(加速車線) ---- */
+for (const [sec, sx] of [['L', -1], ['R', 1]]) {
+  const zTop = C.RAMP_Z_TOP + 14, zEnd = C.RAMP_Z_END - 16;
+  const len = zTop - zEnd, zc = (zTop + zEnd) / 2;
+  const ramp = new THREE.Mesh(new THREE.BoxGeometry(3.6, 0.12, len),
+    new THREE.MeshLambertMaterial({ color: SECTION_THEME[sec].road }));
+  ramp.position.set(15 * sx, -0.055, zc);
+  ramp.receiveShadow = true;
+  scene.add(ramp);
+  const edge = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.02, len), lineMatW);
+  edge.position.set(16.7 * sx, 0.012, zc);
+  scene.add(edge);
+  // 本線との境界は破線(合流可)
+  const dGeo = new THREE.BoxGeometry(0.15, 0.02, 3);
+  for (let z = zEnd + 12; z < zTop - 6; z += 9) {
+    const d = new THREE.Mesh(dGeo, lineMatW);
+    d.position.set(13 * sx, 0.012, z);
+    d.matrixAutoUpdate = false; d.updateMatrix();
+    scene.add(d);
+  }
+  // 終端の導流帯(先細りのゼブラ)
+  for (let i = 0; i < 5; i++) {
+    const w = 3.0 * (1 - i / 5);
+    const zb = new THREE.Mesh(new THREE.BoxGeometry(w, 0.02, 1.3), lineMatW);
+    zb.position.set((13.1 + w / 2) * sx, 0.012, zEnd + 9 - i * 3.2);
+    zb.matrixAutoUpdate = false; zb.updateMatrix();
+    scene.add(zb);
+  }
+}
 
-            const speedFactor = Math.max(0, 1 - (averageSpeedMs / avgDesiredMaxSpeed));
-            
-            const avgCarLengthWithMargin = 7 * 3; 
-            const maxCapacityPerLane = ROAD_LENGTH / avgCarLengthWithMargin;
-            const sectionMaxCapacity = maxCapacityPerLane * numLanes;
-            const densityFactor = Math.min(1, vehicleList.length / sectionMaxCapacity);
-            
-            const score = (speedFactor * 0.70 + densityFactor * 0.30) * 100; 
-            return { 
-                score: Math.min(100, Math.max(0, score)).toFixed(1),
-                averageSpeed: averageSpeedMs 
-            };
-        }
+/* ---- 中央分離帯（ガードレール付き） ---- */
+const delinMat = new THREE.MeshBasicMaterial({ color: 0x9aa3ad }); // 視線誘導標(昼夜で色が変わる)
+(function buildMedian(){
+  const base = new THREE.Mesh(new THREE.BoxGeometry(1.5, 0.5, ROAD_HALF * 2),
+    new THREE.MeshLambertMaterial({ color: 0x9aa0a6 }));
+  base.position.set(0, 0.25, 0); base.castShadow = true; base.receiveShadow = true;
+  scene.add(base);
+  const railMat = new THREE.MeshLambertMaterial({ color: 0xe9edf0 });
+  for (const rx of [-0.6, 0.6]) {
+    const rail = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.14, ROAD_HALF * 2), railMat);
+    rail.position.set(rx, 0.95, 0); scene.add(rail);
+  }
+  const postGeo = new THREE.BoxGeometry(0.12, 0.55, 0.12);
+  const delinGeo = new THREE.BoxGeometry(0.16, 0.16, 0.06); // 視線誘導標(デリネーター)
+  for (let z = -ROAD_HALF + 6; z < ROAD_HALF; z += 18) {
+    const p = new THREE.Mesh(postGeo, railMat);
+    p.position.set(0, 0.75, z);
+    p.matrixAutoUpdate = false; p.updateMatrix();
+    scene.add(p);
+    for (const dz of [-0.09, 0.09]) { // 両進行方向から見えるよう両面に
+      const d = new THREE.Mesh(delinGeo, delinMat);
+      d.position.set(0, 1.12, z + dz);
+      d.matrixAutoUpdate = false; d.updateMatrix();
+      scene.add(d);
+    }
+  }
+})();
 
-        function updateUI() { 
-            totalVehiclesDisplayElement.textContent = `${vehicles.length} / ${MAX_VEHICLES_TOTAL}`; 
-            const leftVehicles = vehicles.filter(v => v.section === 0 && !v.isToBeRemoved);
-            const rightVehicles = vehicles.filter(v => v.section === 1 && !v.isToBeRemoved);
-            
-            leftVehiclesCountDisplayElement.textContent = leftVehicles.length;
-            rightVehiclesCountDisplayElement.textContent = rightVehicles.length;
+/* ---- 路面ペイント（区間ルールの表示・遊び心） ---- */
+function roadText(text, x, z){
+  const cv = document.createElement('canvas');
+  cv.width = 256; cv.height = 640;
+  const ctx = cv.getContext('2d');
+  ctx.clearRect(0, 0, 256, 640);
+  ctx.fillStyle = 'rgba(255,255,255,0.92)';
+  ctx.font = 'bold 118px sans-serif';
+  ctx.textAlign = 'center';
+  text.split('').forEach((c, i) => ctx.fillText(c, 128, 140 + i * 128));
+  const tex = new THREE.CanvasTexture(cv);
+  const m = new THREE.Mesh(new THREE.PlaneGeometry(5, 12.5),
+    new THREE.MeshBasicMaterial({ map: tex, transparent: true, depthWrite: false }));
+  m.rotation.x = -Math.PI / 2;
+  m.rotation.z = 0;
+  m.position.set(x, 0.015, z);
+  scene.add(m);
+}
+roadText('義務あり', -7, -120);
+roadText('義務なし',  7, -120);
+roadText('ゆずりあい', -7, 60);
+roadText('マイペース',  7, 60);
 
-            const leftData = calculateCongestionScore(leftVehicles, NUM_LANES_PER_SIDE); 
-            leftCongestionScoreDisplayElement.textContent = leftData.score;
-            leftAverageSpeedDisplayElement.textContent = (leftData.averageSpeed * 3.6).toFixed(1); 
+/* ---- 頭上標識ゲート(カメラをどう回しても区間が分かるように両面・両端に設置) ---- */
+function makeSignTexture(title, sub, bg){
+  const cv = document.createElement('canvas');
+  cv.width = 512; cv.height = 160;
+  const c2 = cv.getContext('2d');
+  c2.fillStyle = bg;
+  c2.fillRect(0, 0, 512, 160);
+  c2.strokeStyle = '#ffffff';
+  c2.lineWidth = 10;
+  c2.strokeRect(8, 8, 496, 144);
+  c2.fillStyle = '#ffffff';
+  c2.textAlign = 'center';
+  c2.font = 'bold 64px sans-serif';
+  c2.fillText(title, 256, 74);
+  c2.font = 'bold 34px sans-serif';
+  c2.fillText(sub, 256, 126);
+  return new THREE.CanvasTexture(cv);
+}
+function buildGantry(sec, z){
+  const th = SECTION_THEME[sec];
+  const cx = sec === 'L' ? -7 : 7;
+  const g = new THREE.Group();
+  const steel = new THREE.MeshLambertMaterial({ color: 0x99a1aa });
+  for (const px of [cx - 6.9, cx + 6.9]) {
+    const post = new THREE.Mesh(new THREE.BoxGeometry(0.35, 6.6, 0.35), steel);
+    post.position.set(px, 3.3, z);
+    post.castShadow = true;
+    g.add(post);
+  }
+  const beam = new THREE.Mesh(new THREE.BoxGeometry(14.5, 0.4, 0.4), steel);
+  beam.position.set(cx, 6.4, z);
+  beam.castShadow = true;
+  g.add(beam);
+  const tex = makeSignTexture(th.title, th.sub, th.signBg);
+  const boardGeo = new THREE.PlaneGeometry(10.5, 3.3);
+  const boardMat = new THREE.MeshBasicMaterial({ map: tex });
+  for (const dir of [1, -1]) { // 両面に設置(裏からも正しく読める)
+    const board = new THREE.Mesh(boardGeo, boardMat);
+    board.position.set(cx, 8.3, z + dir * 0.06);
+    if (dir === -1) board.rotation.y = Math.PI;
+    g.add(board);
+  }
+  scene.add(g);
+}
+for (const sec of ['L', 'R']) {
+  for (const gz of [-300, -100, 100, 300]) buildGantry(sec, gz);
+}
 
-            const rightData = calculateCongestionScore(rightVehicles, NUM_LANES_PER_SIDE); 
-            rightCongestionScoreDisplayElement.textContent = rightData.score;
-            rightAverageSpeedDisplayElement.textContent = (rightData.averageSpeed * 3.6).toFixed(1); 
-        }
+/* ================= ナイトモード用アセット ================= */
+// 放射状グラデーションのテクスチャ(光だまり・ヘッドライト用)
+function makeGlowTexture(inner, outer){
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = 128;
+  const c2 = cv.getContext('2d');
+  const grad = c2.createRadialGradient(64, 64, 4, 64, 64, 62);
+  grad.addColorStop(0, inner);
+  grad.addColorStop(1, outer);
+  c2.fillStyle = grad;
+  c2.fillRect(0, 0, 128, 128);
+  return new THREE.CanvasTexture(cv);
+}
 
-        function animate() { 
-            if (!simulationRunning) { requestAnimationFrame(animate); return; }
-            requestAnimationFrame(animate);
-            const deltaTime = Math.min(clock.getDelta(), 0.1); 
-            const currentTime = clock.elapsedTime * 1000; 
-            timeSinceLastSpawn += deltaTime * 1000;
+// 夜だけ表示するものをまとめるグループ
+const nightGroup = new THREE.Group();
+nightGroup.visible = false;
+scene.add(nightGroup);
 
-            if (timeSinceLastSpawn > currentSpawnInterval) {
-                if (vehicles.length < MAX_VEHICLES_TOTAL) { 
-                     spawnVehiclePair(); 
-                }
-                timeSinceLastSpawn = 0;
-            }
+// 空: 縦グラデーションのドーム(昼ドームの内側に夜ドームを重ね、opacityでクロスフェード)
+function makeSkyDome(stops, radius, order){
+  const cv = document.createElement('canvas');
+  cv.width = 2; cv.height = 512;
+  const c2 = cv.getContext('2d');
+  const grad = c2.createLinearGradient(0, 0, 0, 512);
+  for (const [o, c] of stops) grad.addColorStop(o, c);
+  c2.fillStyle = grad;
+  c2.fillRect(0, 0, 2, 512);
+  const mesh = new THREE.Mesh(
+    new THREE.SphereGeometry(radius, 32, 15, 0, Math.PI * 2, 0, Math.PI / 2 + 0.22),
+    new THREE.MeshBasicMaterial({ map: new THREE.CanvasTexture(cv), side: THREE.BackSide,
+      fog: false, depthWrite: false, transparent: true })
+  );
+  mesh.renderOrder = order;
+  scene.add(mesh);
+  return mesh;
+}
+makeSkyDome([[0, '#9fc6e4'], [0.55, '#cfe2ee'], [1, '#eef4f6']], 1005, -20); // 昼
+const nightDome = makeSkyDome(
+  [[0, '#02040d'], [0.42, '#0a1226'], [0.76, '#1b2440'], [0.92, '#3a3046'], [1, '#4c3b41']],
+  995, -19); // 夜: 天頂の濃紺 → 地平線の街明かり(暖色)
+nightDome.material.opacity = 0;
 
-            for (let i = vehicles.length - 1; i >= 0; i--) {
-                const vehicle = vehicles[i];
-                if (!vehicle) { 
-                    vehicles.splice(i, 1);
-                    continue;
-                }
+// 星空(夜空ドーム上にランダム配置・天頂寄りに密集)
+const starMat = new THREE.PointsMaterial({ color: 0xdfe8ff, size: 2.2,
+  sizeAttenuation: false, fog: false, transparent: true, opacity: 0, depthWrite: false });
+(function buildStars(){
+  const N = 700, pos = new Float32Array(N * 3);
+  for (let i = 0; i < N; i++) {
+    const th = Math.random() * Math.PI * 2;
+    const ph = Math.acos(0.15 + Math.random() * 0.85); // 地平線近くは疎に
+    const r = 950;
+    pos[i * 3]     = r * Math.sin(ph) * Math.cos(th);
+    pos[i * 3 + 1] = r * Math.cos(ph);
+    pos[i * 3 + 2] = r * Math.sin(ph) * Math.sin(th);
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  const stars = new THREE.Points(geo, starMat);
+  stars.renderOrder = -18;
+  nightGroup.add(stars);
+})();
 
-                if (vehicle.isToBeRemoved) { 
-                    vehicle.dispose(); 
-                    vehicles.splice(i, 1);
-                    continue; 
-                }
-                const otherVehiclesInSection = vehicles.filter(v => v && v.id !== vehicle.id && v.section === vehicle.section && !v.isToBeRemoved);
-                if (vehicle.update) { 
-                    vehicle.update(deltaTime, otherVehiclesInSection);
-                } else {
-                    console.warn("Vehicle object missing update method:", vehicle);
-                }
-            }
-            
-            vehicles = vehicles.filter(vehicle => vehicle && !vehicle.isToBeRemoved);
-            
-            if (controls) controls.update();
-            if (renderer && scene && camera) renderer.render(scene, camera);
-            
-            if (currentTime - lastUiUpdateTime > UI_UPDATE_INTERVAL) {
-                updateUI();
-                lastUiUpdateTime = currentTime;
-            }
-        }
+// 月(ハロー付き)
+const moonMat = new THREE.MeshBasicMaterial({ color: 0xf4f1dc, fog: false, transparent: true, opacity: 0 });
+const haloMat = new THREE.SpriteMaterial({
+  map: makeGlowTexture('rgba(214,226,255,0.30)', 'rgba(214,226,255,0)'),
+  transparent: true, blending: THREE.AdditiveBlending, depthWrite: false, fog: false, opacity: 0 });
+(function buildMoon(){
+  const moon = new THREE.Mesh(new THREE.CircleGeometry(26, 32), moonMat);
+  moon.position.set(330, 520, 260);
+  moon.lookAt(0, 0, 0);
+  moon.renderOrder = -17;
+  nightGroup.add(moon);
+  const halo = new THREE.Sprite(haloMat);
+  halo.scale.set(170, 170, 1);
+  halo.position.copy(moon.position);
+  halo.renderOrder = -17;
+  nightGroup.add(halo);
+})();
 
-        try {
-            init();
-            animate();
-        } catch(e) {
-            console.error("グローバルエラー:", e.message, e.stack, e); 
-            let errorMessage = "実行時エラーが発生しました。";
-            if (e && e.message) {
-                errorMessage += ` メッセージ: ${e.message}`;
-            }
-            showMessage(errorMessage, 5000);
-        }
-    </script>
+// 街灯(中央分離帯から両側へアームを伸ばすダブルアーム式・ナトリウム灯)
+const lampHeadMat = new THREE.MeshLambertMaterial({ color: 0xd8d2b8, emissive: 0x000000 });
+const lampGlowTex = makeGlowTexture('rgba(255,195,107,0.55)', 'rgba(255,195,107,0)');
+const lampGlowMat = new THREE.MeshBasicMaterial({ map: lampGlowTex, transparent: true,
+  blending: THREE.AdditiveBlending, depthWrite: false, opacity: 0 });
+const bulbMat = new THREE.SpriteMaterial({
+  map: makeGlowTexture('rgba(255,216,150,0.9)', 'rgba(255,170,80,0)'),
+  transparent: true, blending: THREE.AdditiveBlending, depthWrite: false, opacity: 0 });
+(function buildStreetLamps(){
+  const poleMat = new THREE.MeshLambertMaterial({ color: 0x6f7780 });
+  const poleGeo = new THREE.BoxGeometry(0.2, 7.2, 0.2);
+  const armGeo  = new THREE.BoxGeometry(5.4, 0.16, 0.16);
+  const headGeo = new THREE.BoxGeometry(0.9, 0.22, 0.42);
+  const glowGeo = new THREE.PlaneGeometry(13, 13);
+  for (let z = -ROAD_HALF + 14; z < ROAD_HALF; z += 42) {
+    const pole = new THREE.Mesh(poleGeo, poleMat);
+    pole.position.set(0, 3.6, z);
+    pole.matrixAutoUpdate = false; pole.updateMatrix();
+    scene.add(pole);
+    const arm = new THREE.Mesh(armGeo, poleMat);
+    arm.position.set(0, 7.1, z);
+    arm.matrixAutoUpdate = false; arm.updateMatrix();
+    scene.add(arm);
+    for (const sx of [-1, 1]) {
+      const head = new THREE.Mesh(headGeo, lampHeadMat);
+      head.position.set(sx * 2.6, 7.0, z);
+      head.matrixAutoUpdate = false; head.updateMatrix();
+      scene.add(head);
+      // 電球のにじみ(夜のみ): 灯具が光源として「光って見える」ように
+      const bulb = new THREE.Sprite(bulbMat);
+      bulb.scale.set(2.6, 2.6, 1);
+      bulb.position.set(sx * 2.6, 6.92, z);
+      nightGroup.add(bulb);
+      // 路面の光だまり(夜のみ)
+      const glow = new THREE.Mesh(glowGeo, lampGlowMat);
+      glow.rotation.x = -Math.PI / 2;
+      glow.position.set(sx * 3.2, 0.03, z);
+      glow.matrixAutoUpdate = false; glow.updateMatrix();
+      nightGroup.add(glow);
+    }
+  }
+})();
+
+// 標識ゲートの投光(夜は案内標識が照明で浮かび上がる)
+const signGlowMat = new THREE.MeshBasicMaterial({
+  map: makeGlowTexture('rgba(255,244,214,0.40)', 'rgba(255,244,214,0)'),
+  transparent: true, blending: THREE.AdditiveBlending, depthWrite: false,
+  side: THREE.DoubleSide, opacity: 0 });
+for (const z of [-300, -100, 100, 300]) {
+  for (const cx of [-7, 7]) {
+    const glow = new THREE.Mesh(new THREE.PlaneGeometry(13.5, 5.6), signGlowMat);
+    glow.position.set(cx, 8.3, z);
+    nightGroup.add(glow);
+  }
+}
+
+// ブレーキ灯のにじみ(共有マテリアル)
+const brakeGlowMat = new THREE.MeshBasicMaterial({
+  map: makeGlowTexture('rgba(255,40,40,0.85)', 'rgba(255,40,40,0)'),
+  transparent: true, blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide });
+const brakeGlowGeo = new THREE.PlaneGeometry(2.0, 0.8);
+
+// ヘッドライトの路面照射(夜のみ・車両ごとに1枚)
+const beamTex = makeGlowTexture('rgba(255,240,190,0.50)', 'rgba(255,240,190,0)');
+const beamMat = new THREE.MeshBasicMaterial({ map: beamTex, transparent: true,
+  blending: THREE.AdditiveBlending, depthWrite: false, opacity: 0 });
+const beamGeo = new THREE.PlaneGeometry(4.6, 9.5);
+
+/* ================= 車両メッシュ ================= */
+const matCache = {};
+function lambert(hex){
+  if (!matCache[hex]) matCache[hex] = new THREE.MeshLambertMaterial({ color: hex });
+  return matCache[hex];
+}
+const glassMat = new THREE.MeshLambertMaterial({ color: 0x223a4d });
+const tireMat  = new THREE.MeshLambertMaterial({ color: 0x1a1a1f });
+const cargoMat = new THREE.MeshLambertMaterial({ color: 0xe8eaee });
+const headMat  = new THREE.MeshLambertMaterial({ color: 0xfff6d8, emissive: 0x6b6346 });
+
+function buildVehicleMesh(v){
+  const t = v.type, L = t.len, W = t.w, H = t.h;
+  const g = new THREE.Group();
+  function add(geo, mat, x, y, z, cast){
+    const m = new THREE.Mesh(geo, mat);
+    m.position.set(x, y, z);
+    if (cast) m.castShadow = true;
+    g.add(m); return m;
+  }
+  const wx = W / 2 - 0.16, wz = L / 2 - 0.95;
+  const wheelGeo = new THREE.BoxGeometry(0.32, 0.72, 0.80);
+  add(wheelGeo, tireMat, -wx, 0.36, -wz); add(wheelGeo, tireMat, wx, 0.36, -wz);
+  add(wheelGeo, tireMat, -wx, 0.36,  wz); add(wheelGeo, tireMat, wx, 0.36,  wz);
+
+  const body = lambert(v.color);
+  switch (v.typeName) {
+    case 'Sedan': {
+      add(new THREE.BoxGeometry(W, H * 0.46, L), body, 0, 0.32 + H * 0.23, 0, true);
+      add(new THREE.BoxGeometry(W * 0.86, H * 0.42, L * 0.50), glassMat, 0, 0.32 + H * 0.66, L * 0.05, true);
+      if (v.isTaxi)
+        add(new THREE.BoxGeometry(0.52, 0.24, 0.32), lambert(0xffa400), 0, 0.32 + H * 0.9 + 0.12, L * 0.05);
+      break;
+    }
+    case 'SportsCar': {
+      add(new THREE.BoxGeometry(W, H * 0.55, L), body, 0, 0.28 + H * 0.275, 0, true);
+      add(new THREE.BoxGeometry(W * 0.80, H * 0.46, L * 0.42), glassMat, 0, 0.28 + H * 0.77, L * 0.04, true);
+      add(new THREE.BoxGeometry(W * 0.95, 0.09, 0.50), body, 0, 0.28 + H * 0.86, L / 2 - 0.30, true);
+      break;
+    }
+    case 'Truck': {
+      const cabL = 2.3;
+      add(new THREE.BoxGeometry(W, 2.4, cabL), body, 0, 0.40 + 1.20, -(L / 2 - cabL / 2), true);
+      add(new THREE.BoxGeometry(W * 0.9, 0.9, 0.10), glassMat, 0, 1.95, -(L / 2 - 0.08));
+      add(new THREE.BoxGeometry(W, H - 0.6, L - cabL - 0.35), cargoMat, 0, 0.55 + (H - 0.6) / 2, (cabL + 0.35) / 2, true);
+      break;
+    }
+    case 'Van': {
+      add(new THREE.BoxGeometry(W, H * 0.80, L), body, 0, 0.32 + H * 0.40, 0, true);
+      add(new THREE.BoxGeometry(W * 0.90, H * 0.34, 0.12), glassMat, 0, 0.32 + H * 0.62, -(L / 2 - 0.25));
+      break;
+    }
+  }
+  // ヘッドライト（前方 = -Z）。マテリアルは全車共有で昼夜一括切替
+  const hGeo = new THREE.BoxGeometry(0.34, 0.16, 0.10);
+  add(hGeo, headMat, -(W / 2 - 0.34), 0.72, -L / 2 - 0.02);
+  add(hGeo, headMat,  (W / 2 - 0.34), 0.72, -L / 2 - 0.02);
+  // ヘッドライトの路面照射(夜のみ表示)
+  const beam = new THREE.Mesh(beamGeo, beamMat);
+  beam.rotation.x = -Math.PI / 2;
+  beam.position.set(0, 0.04, -(L / 2 + 4.2));
+  beam.visible = nightMix > 0.04;
+  g.add(beam);
+  // ブレーキランプ（後方 = +Z）
+  // 灯火類は照明の影響を受けない発光体として描く(昼でもはっきり光って見える)
+  const brakeMat = new THREE.MeshBasicMaterial({ color: 0x4a0b0b });
+  const bGeo = new THREE.BoxGeometry(0.52, 0.22, 0.10);
+  add(bGeo, brakeMat, -(W / 2 - 0.34), 0.74, L / 2 + 0.02);
+  add(bGeo, brakeMat,  (W / 2 - 0.34), 0.74, L / 2 + 0.02);
+  // ウインカー（車線変更時に点滅）
+  const blinkL = new THREE.MeshBasicMaterial({ color: 0x6b4a10 });
+  const blinkR = new THREE.MeshBasicMaterial({ color: 0x6b4a10 });
+  const kGeo = new THREE.BoxGeometry(0.22, 0.2, 0.22);
+  add(kGeo, blinkL, -(W / 2 + 0.02), 0.74,  (L / 2 - 0.12));
+  add(kGeo, blinkL, -(W / 2 + 0.02), 0.74, -(L / 2 - 0.12));
+  add(kGeo, blinkR,  (W / 2 + 0.02), 0.74,  (L / 2 - 0.12));
+  add(kGeo, blinkR,  (W / 2 + 0.02), 0.74, -(L / 2 - 0.12));
+  // ブレーキ時に背面へにじむ赤いグロー(視認性アップ)
+  const bglow = new THREE.Mesh(brakeGlowGeo, brakeGlowMat);
+  bglow.position.set(0, 0.72, L / 2 + 0.18);
+  bglow.visible = false;
+  g.add(bglow);
+  return { group: g, brakeMat, blinkL, blinkR, beam, bglow, prevX: v.x };
+}
+
+/* ================= ワールドとメッシュの同期 ================= */
+const world = new SimCore.World({ rng: Math.random, spawnInterval: 800 });
+const meshMap = new Map();
+
+function syncMeshes(dt){
+  for (const v of world.vehicles) {
+    let m = meshMap.get(v);
+    if (!m) { m = buildVehicleMesh(v); meshMap.set(v, m); scene.add(m.group); }
+    m.group.visible = !v.waiting;
+    if (v.waiting) continue;
+    m.group.position.set(v.x, 0, v.z);
+    const latv = dt > 0 ? (v.x - m.prevX) / dt : 0;
+    m.prevX = v.x;
+    m.group.rotation.y = clamp(-latv / (v.speed + 6), -0.16, 0.16) * 1.5;
+    m.beam.visible = nightMix > 0.04;
+    m.brakeMat.color.setHex(v.braking ? 0xff2a2a : tailIdleHex);
+    m.bglow.visible = v.braking;
+    if (v.braking) brakeGlowMat.opacity = 0.45 + 0.45 * nightMix;
+    const lc = v.lc;
+    const on = lc.state !== 'none' && (Math.floor(performance.now() / 350) % 2 === 0);
+    const dirRight = lc.state !== 'none' && C.LANE_X[v.section][lc.to] > C.LANE_X[v.section][lc.from];
+    // ハザード(両側同時点滅)は車線変更ウインカーより優先して見せる
+    const hz = v.hazard && (Math.floor(performance.now() / 380) % 2 === 0);
+    m.blinkL.color.setHex(hz || (on && !dirRight) ? 0xffb31a : 0x6b4a10);
+    m.blinkR.color.setHex(hz || (on &&  dirRight) ? 0xffb31a : 0x6b4a10);
+  }
+  if (meshMap.size !== world.vehicles.length) {
+    const alive = new Set(world.vehicles);
+    for (const [v, m] of meshMap) {
+      if (!alive.has(v)) { scene.remove(m.group); meshMap.delete(v); }
+    }
+  }
+}
+
+/* ================= UI ================= */
+const els = {
+  count: document.getElementById('vehicleCount'),
+  intervalLabel: document.getElementById('intervalLabel'),
+  slider: document.getElementById('intervalSlider'),
+  countLeft: document.getElementById('countLeft'),
+  countRight: document.getElementById('countRight'),
+  avgLeft: document.getElementById('avgLeft'),
+  avgRight: document.getElementById('avgRight'),
+  scoreLeft: document.getElementById('scoreLeft'),
+  scoreRight: document.getElementById('scoreRight'),
+  barLeft: document.getElementById('barLeft'),
+  barRight: document.getElementById('barRight'),
+  statusLeft: document.getElementById('statusLeft'),
+  statusRight: document.getElementById('statusRight'),
+  crownLeft: document.getElementById('crownLeft'),
+  crownRight: document.getElementById('crownRight'),
+  messageBox: document.getElementById('messageBox')
+};
+
+els.slider.addEventListener('input', function(){
+  world.spawnInterval = parseInt(this.value, 10);
+  els.intervalLabel.textContent = world.spawnInterval;
+});
+document.getElementById('resetBtn').addEventListener('click', function(){
+  world.reset();
+  showMessage('🔄 シミュレーションをリセットしました');
+});
+
+/* ---- ナイトモード切替(約1.6秒の夕暮れクロスフェード) ---- */
+const nightBtn = document.getElementById('nightBtn');
+let nightMix = 0, nightTarget = 0, tailIdleHex = ENV.day.tailIdle;
+const _ca = new THREE.Color(), _cb = new THREE.Color();
+function lerpColor(target, a, b, t){
+  _ca.setHex(a); _cb.setHex(b);
+  target.copy(_ca).lerp(_cb, t);
+}
+function applyEnv(){
+  const d = ENV.day, n = ENV.night, t = nightMix;
+  lerpColor(scene.background, d.bg, n.bg, t);
+  lerpColor(scene.fog.color, d.fogColor, n.fogColor, t);
+  scene.fog.near = d.fogNear + (n.fogNear - d.fogNear) * t;
+  scene.fog.far  = d.fogFar  + (n.fogFar  - d.fogFar)  * t;
+  lerpColor(hemi.color, d.hemiSky, n.hemiSky, t);
+  lerpColor(hemi.groundColor, d.hemiGround, n.hemiGround, t);
+  hemi.intensity = d.hemiInt + (n.hemiInt - d.hemiInt) * t;
+  lerpColor(sun.color, d.sunColor, n.sunColor, t);
+  sun.intensity = d.sunInt + (n.sunInt - d.sunInt) * t;
+  lerpColor(headMat.emissive, d.headEmissive, n.headEmissive, t);
+  lerpColor(glassMat.emissive, d.glassEmissive, n.glassEmissive, t);
+  lerpColor(lampHeadMat.emissive, d.lampEmissive, n.lampEmissive, t);
+  lerpColor(delinMat.color, d.delin, n.delin, t);
+  _ca.setHex(d.tailIdle); _cb.setHex(n.tailIdle);
+  tailIdleHex = _ca.lerp(_cb, t).getHex();
+  // 夜専用アセットはまとめてフェード
+  nightDome.material.opacity = t;
+  nightGroup.visible = t > 0.02;
+  starMat.opacity = t;
+  moonMat.opacity = t;
+  haloMat.opacity = t * 0.9;
+  lampGlowMat.opacity = t;
+  bulbMat.opacity = t;
+  beamMat.opacity = t;
+  signGlowMat.opacity = t;
+}
+function setNight(on){
+  isNight = on;
+  nightTarget = on ? 1 : 0;
+  if (matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    nightMix = nightTarget;
+    applyEnv();
+  }
+  document.body.classList.toggle('night', on);
+  nightBtn.textContent = on ? '☀️ デイモード' : '🌙 ナイトモード';
+}
+nightBtn.addEventListener('click', function(){
+  setNight(!isNight);
+  showMessage(isNight ? '🌙 ナイトモードに切り替えました' : '☀️ デイモードに切り替えました');
+});
+
+let msgTimer = null;
+function showMessage(text){
+  els.messageBox.textContent = text;
+  els.messageBox.classList.add('show');
+  clearTimeout(msgTimer);
+  msgTimer = setTimeout(function(){ els.messageBox.classList.remove('show'); }, 2400);
+}
+
+function statusLabel(score){
+  if (score < 20) return '🚗💨 スイスイ';
+  if (score < 40) return '🙂 順調';
+  if (score < 60) return '😐 やや混雑';
+  if (score < 80) return '😣 渋滞';
+  return '🆘 大渋滞';
+}
+function scoreColor(score){
+  if (score < 30) return '#7CFC9A';
+  if (score < 55) return '#ffd54a';
+  if (score < 75) return '#ff9a3d';
+  return '#ff5c5c';
+}
+
+function updateHUD(){
+  els.count.textContent = world.vehicles.length;
+  const L = world.computeSection('L'), R = world.computeSection('R');
+  els.countLeft.textContent = L.n;
+  els.countRight.textContent = R.n;
+  els.avgLeft.textContent = Math.round(L.avg * 3.6);
+  els.avgRight.textContent = Math.round(R.avg * 3.6);
+  els.scoreLeft.textContent = L.score.toFixed(1);
+  els.scoreRight.textContent = R.score.toFixed(1);
+  els.barLeft.style.width = L.score + '%';
+  els.barRight.style.width = R.score + '%';
+  els.barLeft.style.backgroundColor = scoreColor(L.score);
+  els.barRight.style.backgroundColor = scoreColor(R.score);
+  els.statusLeft.textContent = statusLabel(L.score);
+  els.statusRight.textContent = statusLabel(R.score);
+  const diff = L.score - R.score;
+  els.crownLeft.classList.toggle('show', diff < -5 && L.n > 5);
+  els.crownRight.classList.toggle('show', diff > 5 && R.n > 5);
+  const mL = document.getElementById('miniLeft'), mR = document.getElementById('miniRight');
+  mL.textContent = L.score.toFixed(1);
+  mR.textContent = R.score.toFixed(1);
+  mL.classList.toggle('win', diff < -5 && L.n > 5);
+  mR.classList.toggle('win', diff > 5 && R.n > 5);
+}
+
+/* ================= パネル折りたたみ ================= */
+for (const id of ['controlPanel', 'infoPanel']) {
+  const panel = document.getElementById(id);
+  panel.querySelector('.panel-title').addEventListener('click', function(e){
+    if (e.target.closest('button,input')) return;
+    panel.classList.toggle('collapsed');
+  });
+}
+// 小さい画面では情報を畳んだ状態から始める(3Dの邪魔をしない)
+if (matchMedia('(max-width:700px), (max-height:520px)').matches) {
+  document.getElementById('controlPanel').classList.add('collapsed');
+}
+
+/* ================= パラメータ調整室 ================= */
+const PARAM_DEFS = [
+  { group: 'ルール(比較の核心)' },
+  { key: 'VOLUNTARY_YIELD_RATIO', label: '自発的に譲る人の割合', min: 0, max: 1, step: 0.05, pct: true,
+    desc: '義務なし区間でも自主的に譲る人。1.0にすると両区間は実質同じルールになる' },
+  { key: 'CAMPER_RATIO', label: 'マイペース派の割合', min: 0, max: 1, step: 0.05, pct: true,
+    desc: '譲らない人のうち、追い越し車線を定位置にして巡航する人' },
+  { key: 'OVERTAKE_LANE_RETURN_TIME', label: '義務あり: 戻るまでの時間', min: 0.5, max: 12, step: 0.5, unit: '秒',
+    desc: '義務あり区間で追い越し後に走行車線へ戻るまで' },
+  { key: 'CAMPER_RETURN_TIME_MAX', label: 'マイペース派の居座り(最大)', min: 10, max: 90, step: 5, unit: '秒',
+    desc: '追い越し車線に留まり続ける時間の上限' },
+  { group: '人間ドライバー(両区間共通)' },
+  { key: 'HUMAN_REACTION', label: '知覚の遅れ', min: 0.05, max: 1.5, step: 0.05, unit: '秒',
+    desc: '前の車の速度変化に気づくまでの時間。渋滞波の主因' },
+  { key: 'HUMAN_BRAKE_AMP', label: 'ブレーキの踏みすぎ', min: 1.0, max: 4.0, step: 0.1, unit: '倍',
+    desc: '必要量よりどれだけ強く踏むか。波を後ろへ増幅させる' },
+  { key: 'HUMAN_ACCEL_LAG', label: '再加速の出遅れ', min: 0, max: 3, step: 0.1, unit: '秒',
+    desc: '前が動いてから踏み直すまで。渋滞先頭の流出を減らす' },
+  { key: 'HUMAN_GAIN', label: '車間調整の強さ', min: 0.3, max: 2.0, step: 0.05, unit: '',
+    desc: '車間のズレへの反応の強さ。強いほど波が育ちやすい' },
+  { group: '交通量・スコア' },
+  { key: 'DEMAND_FACTOR', label: '交通需要', min: 40000, max: 220000, step: 5000, unit: '',
+    desc: '同じ生成間隔での目標台数。上げるほど混む(即時反映)' },
+  { key: 'REF_SPEED', label: 'スコア基準速度', min: 15, max: 35, step: 1, unit: 'm/s',
+    desc: '渋滞スコアの基準。25 ≒ 90km/h' },
+];
+const PARAM_DEFAULTS = {};
+for (const d of PARAM_DEFS) if (d.key) PARAM_DEFAULTS[d.key] = SimCore.CONST[d.key];
+function fmtParam(d, v){
+  if (d.pct) return Math.round(v * 100) + '%';
+  return (d.step >= 1 ? Math.round(v).toLocaleString() : v.toFixed(2)) + (d.unit ? ' ' + d.unit : '');
+}
+(function buildParamUI(){
+  const list = document.getElementById('paramList');
+  for (const d of PARAM_DEFS) {
+    if (d.group) {
+      const g = document.createElement('div');
+      g.className = 'pgroup';
+      g.textContent = '── ' + d.group;
+      list.appendChild(g);
+      continue;
+    }
+    const row = document.createElement('div');
+    row.className = 'prow';
+    row.innerHTML = '<div class="plabel"><span>' + d.label + '</span>' +
+      '<span class="pval" id="pv_' + d.key + '"></span></div>' +
+      '<input type="range" id="pr_' + d.key + '" min="' + d.min + '" max="' + d.max + '" step="' + d.step + '">' +
+      '<div class="pdesc">' + d.desc + '</div>';
+    list.appendChild(row);
+    const input = row.querySelector('input');
+    const val = row.querySelector('.pval');
+    input.value = SimCore.CONST[d.key];
+    val.textContent = fmtParam(d, SimCore.CONST[d.key]);
+    input.addEventListener('input', function(){
+      const v = parseFloat(input.value);
+      SimCore.CONST[d.key] = v;
+      val.textContent = fmtParam(d, v);
+    });
+  }
+})();
+const paramOverlay = document.getElementById('paramOverlay');
+document.getElementById('paramsBtn').addEventListener('click', function(){
+  paramOverlay.classList.add('open');
+});
+function closeParams(){ paramOverlay.classList.remove('open'); }
+document.getElementById('paramClose').addEventListener('click', closeParams);
+paramOverlay.addEventListener('click', function(e){ if (e.target === paramOverlay) closeParams(); });
+window.addEventListener('keydown', function(e){ if (e.key === 'Escape') closeParams(); });
+document.getElementById('paramApply').addEventListener('click', function(){
+  closeParams();
+  document.getElementById('resetBtn').click();
+});
+document.getElementById('paramDefaults').addEventListener('click', function(){
+  for (const d of PARAM_DEFS) {
+    if (!d.key) continue;
+    SimCore.CONST[d.key] = PARAM_DEFAULTS[d.key];
+    document.getElementById('pr_' + d.key).value = PARAM_DEFAULTS[d.key];
+    document.getElementById('pv_' + d.key).textContent = fmtParam(d, PARAM_DEFAULTS[d.key]);
+  }
+  showMessage('パラメータを既定値に戻しました');
+});
+
+/* ================= カメラ操作（回転・ズーム） ================= */
+const camCtrl = { theta: 0, phi: 1.06, radius: 105, target: new THREE.Vector3(0, 0, 0) };
+function updateCamera(){
+  const c = camCtrl;
+  camera.position.set(
+    c.target.x + c.radius * Math.sin(c.phi) * Math.sin(c.theta),
+    c.target.y + c.radius * Math.cos(c.phi),
+    c.target.z + c.radius * Math.sin(c.phi) * Math.cos(c.theta)
+  );
+  camera.lookAt(c.target);
+}
+(function setupCameraControls(){
+  const dom = renderer.domElement;
+  const pointers = new Map();
+  let pinchDist = 0;
+  dom.addEventListener('pointerdown', function(e){
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    dom.setPointerCapture(e.pointerId);
+    if (pointers.size === 2) {
+      const p = Array.from(pointers.values());
+      pinchDist = Math.hypot(p[0].x - p[1].x, p[0].y - p[1].y);
+    }
+  });
+  dom.addEventListener('pointermove', function(e){
+    if (!pointers.has(e.pointerId)) return;
+    const prev = pointers.get(e.pointerId);
+    const dx = e.clientX - prev.x, dy = e.clientY - prev.y;
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointers.size === 1) {
+      camCtrl.theta -= dx * 0.005;
+      camCtrl.phi = clamp(camCtrl.phi - dy * 0.004, 0.25, 1.45);
+    } else if (pointers.size === 2) {
+      const p = Array.from(pointers.values());
+      const d = Math.hypot(p[0].x - p[1].x, p[0].y - p[1].y);
+      if (pinchDist > 0) camCtrl.radius = clamp(camCtrl.radius * (pinchDist / d), 30, 240);
+      pinchDist = d;
+    }
+  });
+  function release(e){ pointers.delete(e.pointerId); pinchDist = 0; }
+  dom.addEventListener('pointerup', release);
+  dom.addEventListener('pointercancel', release);
+  dom.addEventListener('wheel', function(e){
+    e.preventDefault();
+    camCtrl.radius = clamp(camCtrl.radius * (1 + e.deltaY * 0.0011), 30, 240);
+  }, { passive: false });
+})();
+
+/* ================= メインループ ================= */
+const clock = new THREE.Clock();
+let hudAccum = 0;
+
+function animate(){
+  requestAnimationFrame(animate);
+  const dt = Math.min(clock.getDelta(), 0.05);
+  if (nightMix !== nightTarget) { // 夕暮れ/夜明けのクロスフェード
+    nightMix = nightTarget > nightMix
+      ? Math.min(nightTarget, nightMix + dt / 1.6)
+      : Math.max(nightTarget, nightMix - dt / 1.6);
+    applyEnv();
+  }
+  world.step(dt);
+  syncMeshes(dt);
+  hudAccum += dt;
+  if (hudAccum >= 0.25) { hudAccum = 0; updateHUD(); }
+  updateCamera();
+  renderer.render(scene, camera);
+}
+
+window.addEventListener('resize', function(){
+  camera.aspect = innerWidth / innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth, innerHeight);
+});
+
+/* ================= 開始 ================= */
+try {
+  world.populateInitial();
+  els.intervalLabel.textContent = world.spawnInterval;
+  applyEnv();
+  updateHUD();
+  updateCamera();
+  animate();
+  showMessage('🟢 緑 = 義務あり(ゆずる) ／ 🟠 オレンジ = 義務なし — 標識と路肩の色が目印');
+} catch (e) {
+  showError(e.message);
+  throw e;
+}
+})();
+</script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "traffic-jam-simulation",
+  "version": "1.0.0",
+  "description": "6車線比較 渋滞シミュレーション",
+  "private": true,
+  "scripts": {
+    "test": "node traffic-simulation.test.js"
+  }
+}

--- a/traffic-simulation.test.js
+++ b/traffic-simulation.test.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * 6車線比較 渋滞シミュレーション テスト
+ *
+ * index.html 内の <script id="sim-core"> ブロック
+ * （DOM / THREE 非依存のシミュレーションロジック）を抽出して検証する。
+ *
+ * 実行方法:  node traffic-simulation.test.js
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+/* ---------- sim-core の読み込み ---------- */
+const htmlPath = path.join(__dirname, 'index.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+const m = html.match(/<script id="sim-core">([\s\S]*?)<\/script>/);
+if (!m) { console.error('sim-core ブロックが見つかりません'); process.exit(1); }
+const ctx = vm.createContext({});
+vm.runInContext(m[1], ctx, { filename: 'sim-core.js' });
+const SimCore = ctx.SimCore;
+const { World, Vehicle, createRng, CONST } = SimCore;
+
+/* ---------- 簡易テストランナー ---------- */
+let passed = 0, failed = 0;
+function test(name, fn){
+  try { fn(); passed++; console.log(`  ✅ ${name}`); }
+  catch (e) { failed++; console.log(`  ❌ ${name}\n     → ${e.message}`); }
+}
+function assert(cond, msg){ if (!cond) throw new Error(msg); }
+function approx(a, b, eps, msg){ if (Math.abs(a - b) > eps) throw new Error(`${msg} (got ${a}, want ${b}±${eps})`); }
+
+/* ---------- ヘルパー: シナリオ実行 ---------- */
+const DT = 1 / 20;
+function runScenario(seed, opts){
+  opts = opts || {};
+  const seconds = opts.seconds || 300;
+  const measureFrom = opts.measureFrom || 120;
+  const w = new World({ rng: createRng(seed), spawnInterval: opts.interval || 800 });
+  w.populateInitial();
+  let sumL = 0, sumR = 0, samples = 0, minGap = Infinity;
+  const steps = Math.round(seconds / DT);
+  for (let i = 0; i < steps; i++) {
+    w.step(DT);
+    const t = i * DT;
+    if (i % 10 === 0) {
+      // 貫通チェック（同一車線・車線変更中でない車両同士）
+      for (const sec of ['L', 'R']) {
+        const arr = w._sec[sec];
+        for (let k = 1; k < arr.length; k++) {
+          const a = arr[k - 1], b = arr[k];
+          if (a.lc.state !== 'none' || b.lc.state !== 'none') continue;
+          if (a.lane !== b.lane) continue;
+          const gap = Math.abs(b.z - a.z) - (a.length + b.length) / 2;
+          if (gap < minGap) minGap = gap;
+        }
+      }
+      if (t >= measureFrom) {
+        sumL += w.computeSection('L').score;
+        sumR += w.computeSection('R').score;
+        samples++;
+      }
+    }
+  }
+  return { L: sumL / samples, R: sumR / samples, minGap, world: w };
+}
+
+/* ============================================================
+   1. メイン要件: 渋滞スコアに約10ポイントの差が出ること
+   人間らしい運転モデル(ブレーキ連鎖・渋滞波)導入後は渋滞が準安定
+   状態を持つため、シードごとの差は±4〜5程度ゆらぐ。個別シードは
+   10±4.5、5シード平均は10±2で判定する。
+   ============================================================ */
+console.log('\n■ 渋滞スコア差（義務あり vs 義務なし）');
+const SEEDS = [11, 22, 33, 44, 55];
+const DIFF_TARGET = 10, DIFF_TOL = 4.5;
+const results = [];
+for (const seed of SEEDS) {
+  const r = runScenario(seed);
+  results.push({ seed, ...r });
+}
+for (const r of results) {
+  const diff = Math.round((r.R - r.L) * 10) / 10; // 表示と同じ精度で判定する
+  test(`seed=${r.seed}: 義務なし側のスコアが約10ポイント高い ` +
+       `(義務あり ${r.L.toFixed(1)} / 義務なし ${r.R.toFixed(1)} → 差 ${diff.toFixed(1)})`,
+    () => {
+      assert(r.R > r.L, `義務なし側の方が渋滞するはずが逆転 (L=${r.L.toFixed(1)}, R=${r.R.toFixed(1)})`);
+      assert(Math.abs(diff - DIFF_TARGET) <= DIFF_TOL,
+        `スコア差 ${diff.toFixed(1)} が目標 ${DIFF_TARGET}±${DIFF_TOL} の範囲外`);
+    });
+}
+{
+  const avg = results.reduce((s, r) => s + (r.R - r.L), 0) / results.length;
+  test(`5シード平均のスコア差が ${DIFF_TARGET}±2 に収まる (平均 ${avg.toFixed(1)})`,
+    () => assert(Math.abs(avg - DIFF_TARGET) <= 2, `平均差 ${avg.toFixed(1)} が範囲外`));
+  console.log(`  📊 平均スコア差: ${avg.toFixed(1)} ポイント (全${SEEDS.length}シード)`);
+}
+
+/* ============================================================
+   2. 「追いつかれた車両の義務」の挙動
+   ============================================================ */
+console.log('\n■ 追いつかれた車両の義務');
+test('義務あり区間: 速い後続車が迫ると左車線へ譲る', () => {
+  const w = new World({ rng: createRng(1), spawnInterval: 1e9 });
+  const slow = new Vehicle(w, 'L', 1, 0, 'Truck', 16);   slow.speed = 16;
+  const fast = new Vehicle(w, 'L', 1, 40, 'SportsCar', 34); fast.speed = 32;
+  w.vehicles.push(slow, fast);
+  let yielded = false;
+  for (let i = 0; i < 400; i++) {
+    w.step(DT);
+    if (slow.lane === 2 || (slow.lc.state !== 'none' && slow.lc.to === 2)) { yielded = true; break; }
+  }
+  assert(yielded, '左車線(レーン2)へ譲る車線変更が発生しなかった');
+});
+
+test('義務なし区間: 同じ状況でも譲らない', () => {
+  const w = new World({ rng: createRng(1), spawnInterval: 1e9 });
+  const slow = new Vehicle(w, 'R', 1, 0, 'Truck', 16);   slow.speed = 16;
+  const fast = new Vehicle(w, 'R', 1, 40, 'SportsCar', 34); fast.speed = 32;
+  w.vehicles.push(slow, fast);
+  let yielded = false;
+  for (let i = 0; i < 400; i++) {
+    w.step(DT);
+    if (slow.lane === 2 || (slow.lc.state !== 'none' && slow.lc.to === 2)) { yielded = true; break; }
+  }
+  assert(!yielded, '義務がないのに左車線へ譲ってしまった');
+});
+
+/* ============================================================
+   3. 追い越し挙動（両区間共通）
+   ============================================================ */
+console.log('\n■ 追い越し');
+for (const sec of ['L', 'R']) {
+  const name = sec === 'L' ? '義務あり' : '義務なし';
+  test(`${name}区間: 遅い前方車がいれば右(追い越し車線)へ出る`, () => {
+    const w = new World({ rng: createRng(2), spawnInterval: 1e9 });
+    const slow = new Vehicle(w, sec, 2, 0, 'Truck', 16);    slow.speed = 16;
+    const fast = new Vehicle(w, sec, 2, 60, 'SportsCar', 34); fast.speed = 34;
+    w.vehicles.push(slow, fast);
+    let overtook = false;
+    // 人間モデルでは「しばらく抑え込まれてから」追い越しを決意するため長めに観察
+    for (let i = 0; i < 1600; i++) {
+      w.step(DT);
+      if (fast.lane < 2 || (fast.lc.state !== 'none' && fast.lc.to < 2)) { overtook = true; break; }
+    }
+    assert(overtook, '追い越し車線への車線変更が発生しなかった');
+  });
+}
+
+test('義務あり区間: 追い越し後は走行車線へ復帰する', () => {
+  const w = new World({ rng: createRng(3), spawnInterval: 1e9 });
+  const v = new Vehicle(w, 'L', 0, 0, 'Sedan', 26); v.speed = 26;
+  w.vehicles.push(v);
+  let returned = false;
+  for (let i = 0; i < Math.round((CONST.OVERTAKE_LANE_RETURN_TIME + 4) / DT); i++) {
+    w.step(DT);
+    if (v.lane === 1 || (v.lc.state !== 'none' && v.lc.to === 1)) { returned = true; break; }
+  }
+  assert(returned, '追い越し車線から復帰しなかった');
+});
+
+test('義務なし区間: 復帰は義務あり区間より明確に遅い設定', () => {
+  const w = new World({ rng: createRng(4), spawnInterval: 1e9 });
+  for (let i = 0; i < 40; i++) {
+    const v = new Vehicle(w, 'R', 0, i * 10, 'Sedan', 26);
+    assert(v.returnTime >= CONST.OVERTAKE_LANE_RETURN_TIME * 3,
+      `returnTime=${v.returnTime.toFixed(1)}s は短すぎる`);
+  }
+});
+
+/* ============================================================
+   4. 安全性: 車両の貫通防止
+   ============================================================ */
+console.log('\n■ 衝突回避・貫通防止');
+test('長時間運転しても同一車線内で車両が重ならない (許容 -1.0m)', () => {
+  let worstGap = Infinity;
+  for (const r of results) worstGap = Math.min(worstGap, r.minGap);
+  assert(worstGap > -1.0, `車間が ${worstGap.toFixed(2)}m まで縮まり貫通が発生`);
+});
+
+/* ============================================================
+   5. 渋滞スコアの計算式 (速度75% + 密度25%)
+   ============================================================ */
+console.log('\n■ ハザードランプ');
+test('停止列の最後尾はハザードを点灯し、後続が停車したら次の最後尾へ移る', () => {
+  const w = new World({ rng: createRng(3), spawnInterval: 1e9 });
+  const tail = new Vehicle(w, 'L', 1, 0, 'Sedan', 25);
+  tail.speed = 0;
+  w.vehicles.push(tail);
+  w.step(DT);
+  assert(tail.hazard, '最後尾(後続なし)でハザードが点かない');
+  const f = new Vehicle(w, 'L', 1, 8, 'Sedan', 25); // 直後で停車した後続
+  f.speed = 0;
+  w.vehicles.push(f);
+  w.step(DT);
+  assert(!tail.hazard, '後続が停車してもハザードが消えない');
+  assert(f.hazard, '新しい最後尾にハザードが移らない');
+});
+
+console.log('\n■ 渋滞スコア算出');
+test('スコア = (0.75×速度要因 + 0.25×密度要因) × 100', () => {
+  const w = new World({ rng: createRng(5), spawnInterval: 1e9 });
+  for (let i = 0; i < 4; i++) {
+    const v = new Vehicle(w, 'L', i % 3, i * 30, 'Sedan', 24);
+    v.speed = 16;
+    w.vehicles.push(v);
+  }
+  const s = w.computeSection('L');
+  const expected = (0.75 * (1 - 16 / CONST.REF_SPEED) + 0.25 * (4 / CONST.MAX_PER_SECTION)) * 100;
+  approx(s.score, expected, 1e-9, 'スコア計算式が仕様と不一致');
+  assert(s.n === 4, `車両数カウント不一致: ${s.n}`);
+});
+
+test('車両ゼロのときスコアは0', () => {
+  const w = new World({ rng: createRng(6) });
+  assert(w.computeSection('L').score === 0, 'スコアが0でない');
+});
+
+/* ============================================================
+   6. ペア生成
+   ============================================================ */
+console.log('\n■ 車両ペア生成');
+test('ペアは同タイプ・同初期速度で左右に1台ずつ生成される', () => {
+  const w = new World({ rng: createRng(7), spawnInterval: 1e9 });
+  assert(w.spawnPair(), 'spawnPairが失敗');
+  assert(w.vehicles.length === 2, `生成台数 ${w.vehicles.length} ≠ 2`);
+  const [a, b] = w.vehicles;
+  assert(a.section === 'L' && b.section === 'R', 'セクション割り当てが不正');
+  assert(a.typeName === b.typeName, 'ペアのタイプが不一致');
+  approx(a.initialDesiredSpeed, b.initialDesiredSpeed, 1e-12, 'ペアの初期速度が不一致');
+});
+
+test('最大車両数280台を超えない', () => {
+  const w = new World({ rng: createRng(8), spawnInterval: 50 });
+  w.populateInitial();
+  for (let i = 0; i < Math.round(300 / DT); i++) w.step(DT);
+  assert(w.vehicles.length <= CONST.MAX_VEHICLES,
+    `${w.vehicles.length}台 > 上限${CONST.MAX_VEHICLES}台`);
+});
+
+/* ---------- 結果 ---------- */
+console.log(`\n${'='.repeat(56)}`);
+console.log(`結果: ${passed} passed / ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## 概要
`index.html` の中身を新しい「6車線比較 渋滞シミュレーション」に置き換え、シミュレーションロジックのテストと CI を追加しました。

## 変更内容
- **`index.html`**: DOM / THREE 非依存のシミュレーションコア (`<script id="sim-core">`) と、Three.js による描画・UI を分離した構成に刷新。「義務あり（ゆずりあい）」区間と「義務なし（マイペース）」区間を左右に並べて渋滞スコアを比較します。
- **`traffic-simulation.test.js`**: `index.html` から `sim-core` ブロックを抽出して `vm` 上で検証する Node テスト（依存パッケージなし）。渋滞スコア差・追いつかれた車両の義務・追い越し／復帰挙動・貫通防止・スコア計算式・ペア生成など計 18 ケース。
- **`.github/workflows/test.yml`**: push / pull_request で `node traffic-simulation.test.js` を実行する GitHub Actions ワークフロー。
- **`package.json`**: `npm test` で同テストを実行できるように追加。

## テスト
ローカルで全 18 ケースが成功することを確認済みです。

```
結果: 18 passed / 0 failed
```

## 補足
テストコードは元々 `traffic-simulation.html` を参照していましたが、本リポジトリの正となる HTML ファイルは `index.html` のため、参照先を `index.html` に合わせています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpmA7dYfDL1R9ES8DMPEYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpmA7dYfDL1R9ES8DMPEYT)_