### PR TITLE
lucideアイコンのレイアウト崩れを修正 (inline-block固定)

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,9 @@
   }
 
   /* ---- lucide アイコン(絵文字を差し替えた線画アイコン) ---- */
-  .lucide{width:1.05em;height:1.05em;vertical-align:-.16em;stroke-width:2.2;flex:none;}
+  /* Tailwind の Preflight が svg{display:block} を当てるため、明示的に
+     inline-block へ戻してテキストと横並びに保つ(これが無いと改行して崩れる) */
+  .lucide{display:inline-block;width:1.05em;height:1.05em;vertical-align:-.16em;stroke-width:2.2;flex:none;}
   button .lucide{margin-right:6px;}
   .hint .lucide{margin-right:5px;color:#ffe9a8;}
   .fair-note .lucide{margin-right:5px;}


### PR DESCRIPTION
## 概要

マージ済みの lucide アイコン導入 (#3) 後に発生していた **UI のレイアウト崩れ**を修正します。

## 問題

Tailwind の Preflight（CSSリセット）が `svg { display: block }` を適用するため、lucide が生成する `<svg>` アイコンがブロック要素になり、ボタンや見出しの中でアイコンとテキストが**改行**して崩れていました（例: ボタンのアイコンが左上に飛び出し、文字が下段へ落ちる／paddingが不自然になる）。

## 修正

`.lucide` に `display:inline-block` を明示。クラスセレクタなので Tailwind の `svg` 要素セレクタより優先され、アイコンがテキストと横並びに戻ります。

```css
.lucide{display:inline-block;width:1.05em;height:1.05em;vertical-align:-.16em;stroke-width:2.2;flex:none;}
```

変更は1行（+コメント）のみです。

## 検証

- Tailwind の Preflight を効かせた状態でヘッドレス Chromium により実レンダリングし、コントロールパネル・渋滞スコア比較パネル・パラメータ調整室のすべてでアイコンがテキストと横並びに戻り、padding が正常であることをスクリーンショットで確認。
- `npm test` → **18 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wh1SjgMgz5dYJntpLiuUzV)_