### PR TITLE
描画をリアル化: 実車らしい車体・背景美術・運転の個性を追加

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 import { World } from './core';
 import { scene, camera, renderer } from './render/scene';
 import './render/track';
+import './render/scenery';
 import { applyEnv, tickTheme } from './render/theme';
 import { syncMeshes } from './render/vehicle-mesh';
 import { updateCamera, setupCameraControls } from './render/camera';

--- a/src/render/materials.ts
+++ b/src/render/materials.ts
@@ -18,19 +18,175 @@ export function makeGlowTexture(inner: string, outer: string): THREE.CanvasTextu
 }
 
 /* ---- 車両ボディ(色ごとに共有) ---- */
-const matCache: Record<number, THREE.MeshLambertMaterial> = {};
-export function lambert(hex: number): THREE.MeshLambertMaterial {
-  if (!matCache[hex]) matCache[hex] = new THREE.MeshLambertMaterial({ color: hex });
+// 車体塗装: 光沢のあるPhongで金属塗装の照り返しを出す
+const matCache: Record<number, THREE.MeshPhongMaterial> = {};
+export function paint(hex: number): THREE.MeshPhongMaterial {
+  if (!matCache[hex])
+    matCache[hex] = new THREE.MeshPhongMaterial({ color: hex, shininess: 80, specular: 0x8a8a8a });
   return matCache[hex];
 }
-export const glassMat = new THREE.MeshLambertMaterial({ color: 0x223a4d });
-export const tireMat = new THREE.MeshLambertMaterial({ color: 0x1a1a1f });
+export const glassMat = new THREE.MeshPhongMaterial({
+  color: 0x18242e,
+  shininess: 130,
+  specular: 0xa8c8e0,
+});
+export const tireMat = new THREE.MeshLambertMaterial({ color: 0x141419 });
+export const hubMat = new THREE.MeshPhongMaterial({
+  color: 0x9ba3ae,
+  shininess: 100,
+  specular: 0xe0e0e0,
+});
 export const cargoMat = new THREE.MeshLambertMaterial({ color: 0xe8eaee });
-export const headMat = new THREE.MeshLambertMaterial({ color: 0xfff6d8, emissive: 0x6b6346 });
+export const trimMat = new THREE.MeshLambertMaterial({ color: 0x23272c }); // バンパー等の樹脂部品
+export const plateMat = new THREE.MeshLambertMaterial({ color: 0xf2f4ea }); // ナンバープレート
+export const headMat = new THREE.MeshPhongMaterial({
+  color: 0xfff6d8,
+  emissive: 0x6b6346,
+  shininess: 120,
+});
 
 /* ---- 道路施設(昼夜で色が変わるもの) ---- */
 export const delinMat = new THREE.MeshBasicMaterial({ color: 0x9aa3ad }); // 視線誘導標
 export const lampHeadMat = new THREE.MeshLambertMaterial({ color: 0xd8d2b8, emissive: 0x000000 }); // 街灯灯具
+
+/* ---- 背景テクスチャ(草地・アスファルト) ---- */
+export function makeGrassTexture(): THREE.CanvasTexture {
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = 256;
+  const c2 = cv.getContext('2d')!;
+  c2.fillStyle = '#7c9a66';
+  c2.fillRect(0, 0, 256, 256);
+  // 濃淡のむら + 草の粒感
+  for (let i = 0; i < 2600; i++) {
+    const gr = 120 + Math.random() * 60;
+    c2.fillStyle =
+      'rgba(' +
+      Math.round(gr * 0.72) +
+      ',' +
+      Math.round(gr) +
+      ',' +
+      Math.round(gr * 0.52) +
+      ',' +
+      (0.08 + Math.random() * 0.16).toFixed(2) +
+      ')';
+    const s = 1 + Math.random() * 3;
+    c2.fillRect(Math.random() * 256, Math.random() * 256, s, s);
+  }
+  const tex = new THREE.CanvasTexture(cv);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(56, 56);
+  return tex;
+}
+export function makeAsphaltTexture(): THREE.CanvasTexture {
+  const cv = document.createElement('canvas');
+  cv.width = 256;
+  cv.height = 512;
+  const c2 = cv.getContext('2d')!;
+  c2.fillStyle = '#b9babd'; // Lambertのcolorと乗算されるため明るめに描く
+  c2.fillRect(0, 0, 256, 512);
+  for (let i = 0; i < 5200; i++) {
+    // 骨材の粒
+    const gr = Math.round(130 + Math.random() * 120);
+    c2.fillStyle =
+      'rgba(' +
+      gr +
+      ',' +
+      gr +
+      ',' +
+      (gr + 6) +
+      ',' +
+      (0.05 + Math.random() * 0.12).toFixed(2) +
+      ')';
+    c2.fillRect(
+      Math.random() * 256,
+      Math.random() * 512,
+      1 + Math.random() * 2,
+      1 + Math.random() * 2,
+    );
+  }
+  // 轍(わだち): タイヤが通る位置はゴムと油で黒ずむ。3車線ぶん左右2本ずつ
+  for (const u of [0.197, 0.5, 0.803]) {
+    // 路面幅13.2mに対する各車線中心
+    for (const d of [-1, 1]) {
+      const x = (u + d * 0.062) * 256;
+      const grad = c2.createLinearGradient(x - 15, 0, x + 15, 0);
+      grad.addColorStop(0, 'rgba(40,40,44,0)');
+      grad.addColorStop(0.5, 'rgba(40,40,44,0.22)');
+      grad.addColorStop(1, 'rgba(40,40,44,0)');
+      c2.fillStyle = grad;
+      c2.fillRect(x - 15, 0, 30, 512);
+    }
+  }
+  // 補修痕・シミ
+  for (let i = 0; i < 26; i++) {
+    c2.fillStyle = 'rgba(52,52,58,' + (0.05 + Math.random() * 0.09).toFixed(2) + ')';
+    c2.fillRect(
+      Math.random() * 256,
+      Math.random() * 512,
+      6 + Math.random() * 40,
+      3 + Math.random() * 14,
+    );
+  }
+  const tex = new THREE.CanvasTexture(cv);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(1, 34);
+  return tex;
+}
+export const asphaltTex = makeAsphaltTexture();
+
+/* ---- 遠景の山並み(白で描き、themeがcolorで昼夜の色を乗せる) ---- */
+function makeRidgeTexture(jag: number, base: number): THREE.CanvasTexture {
+  const cv = document.createElement('canvas');
+  cv.width = 1024;
+  cv.height = 256;
+  const c2 = cv.getContext('2d')!;
+  c2.fillStyle = '#ffffff';
+  c2.beginPath();
+  c2.moveTo(0, 256);
+  let y = base;
+  c2.lineTo(0, y);
+  for (let x = 16; x <= 1024; x += 16) {
+    // ランダムウォークで稜線を描く
+    y = Math.min(200, Math.max(40, y + (Math.random() - 0.5) * jag));
+    c2.lineTo(x, y);
+  }
+  c2.lineTo(1024, 256);
+  c2.closePath();
+  c2.fill();
+  // 裾野をフェードさせて霧・地面と馴染ませる
+  c2.globalCompositeOperation = 'destination-out';
+  const g = c2.createLinearGradient(0, 150, 0, 256);
+  g.addColorStop(0, 'rgba(0,0,0,0)');
+  g.addColorStop(1, 'rgba(0,0,0,1)');
+  c2.fillStyle = g;
+  c2.fillRect(0, 150, 1024, 106);
+  return new THREE.CanvasTexture(cv);
+}
+export const mtnFarMat = new THREE.MeshBasicMaterial({
+  map: makeRidgeTexture(46, 120),
+  transparent: true,
+  side: THREE.BackSide,
+  fog: false,
+  depthWrite: false,
+  color: 0xb9cbd9,
+});
+export const mtnNearMat = new THREE.MeshBasicMaterial({
+  map: makeRidgeTexture(85, 165),
+  transparent: true,
+  side: THREE.BackSide,
+  fog: false,
+  depthWrite: false,
+  color: 0x93aabf,
+});
+
+/* ---- 雲(昼のみ。夜はthemeがフェードアウト) ---- */
+export const cloudMat = new THREE.SpriteMaterial({
+  map: makeGlowTexture('rgba(255,255,255,0.85)', 'rgba(255,255,255,0)'),
+  transparent: true,
+  depthWrite: false,
+  fog: false,
+  opacity: 0.9,
+});
 
 /* ---- 夜景アセット(opacityをテーマがフェード) ---- */
 // 星空

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,5 +1,6 @@
 /* ================= Three.js セットアップ(シーン・カメラ・ライト) ================= */
 import * as THREE from 'three';
+import { makeGrassTexture } from './materials';
 
 export const SKY = 0xcfe2ee;
 
@@ -39,10 +40,10 @@ sun.shadow.camera.far = 500;
 sun.shadow.bias = -0.0006;
 scene.add(sun);
 
-/* ---- 地面（背景の透け防止のため広く・低く配置） ---- */
+/* ---- 地面（草地。背景の透け防止のため広く・低く配置） ---- */
 const ground = new THREE.Mesh(
   new THREE.PlaneGeometry(1600, 1600),
-  new THREE.MeshLambertMaterial({ color: 0x7d9a6a }),
+  new THREE.MeshLambertMaterial({ color: 0xffffff, map: makeGrassTexture() }),
 );
 ground.rotation.x = -Math.PI / 2;
 ground.position.y = -0.18;

--- a/src/render/scenery.ts
+++ b/src/render/scenery.ts
@@ -1,0 +1,133 @@
+/* ================= 背景美術(路側・並木・遠景) =================
+   道路施設(track.js)とは別の「風景」を担当する。
+   山・雲のマテリアルは materials.js にあり、昼夜の色は theme.js が補間する */
+import * as THREE from 'three';
+import { CONST as C } from '../core';
+import { scene } from './scene';
+import { mtnFarMat, mtnNearMat, cloudMat } from './materials';
+
+const ROAD_HALF = C.ROAD_HALF;
+
+/* ---- 路側の防護柵(ガードレール) ---- */
+(function buildRoadside() {
+  const railMat = new THREE.MeshPhongMaterial({ color: 0xdfe4e8, shininess: 60 });
+  const postMat = new THREE.MeshLambertMaterial({ color: 0xb8bfc6 });
+  const postGeo = new THREE.BoxGeometry(0.12, 0.8, 0.12);
+  for (const sx of [-1, 1]) {
+    const rail = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.3, ROAD_HALF * 2), railMat);
+    rail.position.set(18.2 * sx, 0.62, 0);
+    scene.add(rail);
+    for (let z = -ROAD_HALF + 4; z < ROAD_HALF; z += 12) {
+      const p = new THREE.Mesh(postGeo, postMat);
+      p.position.set(18.2 * sx, 0.4, z);
+      p.matrixAutoUpdate = false;
+      p.updateMatrix();
+      scene.add(p);
+    }
+  }
+  // 遮音壁: 下段コンクリート + 上段の半透明パネル(高速道路らしさ)
+  const wallMat = new THREE.MeshLambertMaterial({ color: 0xb4b9bd });
+  const panelMat = new THREE.MeshLambertMaterial({
+    color: 0x9fd3c8,
+    transparent: true,
+    opacity: 0.38,
+  });
+  const wpostMat = new THREE.MeshLambertMaterial({ color: 0x7c858d });
+  const wpostGeo = new THREE.BoxGeometry(0.22, 3.2, 0.22);
+  for (const sx of [-1, 1]) {
+    const z0 = -380,
+      z1 = -130,
+      len = z1 - z0,
+      zc = (z0 + z1) / 2;
+    const base = new THREE.Mesh(new THREE.BoxGeometry(0.3, 1.5, len), wallMat);
+    base.position.set(19.2 * sx, 0.75, zc);
+    base.castShadow = true;
+    scene.add(base);
+    const panel = new THREE.Mesh(new THREE.BoxGeometry(0.14, 1.7, len), panelMat);
+    panel.position.set(19.2 * sx, 2.35, zc);
+    scene.add(panel);
+    for (let z = z0; z <= z1; z += 10) {
+      const p = new THREE.Mesh(wpostGeo, wpostMat);
+      p.position.set(19.2 * sx, 1.6, z);
+      p.matrixAutoUpdate = false;
+      p.updateMatrix();
+      scene.add(p);
+    }
+  }
+})();
+
+/* ---- 並木・雑木林(InstancedMeshで軽量に大量配置) ---- */
+(function buildTrees() {
+  const N = 130;
+  const trunkGeo = new THREE.CylinderGeometry(0.1, 0.18, 1, 5);
+  trunkGeo.translate(0, 0.5, 0);
+  const canopyGeo = new THREE.IcosahedronGeometry(1, 0);
+  const trunks = new THREE.InstancedMesh(
+    trunkGeo,
+    new THREE.MeshLambertMaterial({ color: 0x6b4e35 }),
+    N,
+  );
+  const canopies = new THREE.InstancedMesh(
+    canopyGeo,
+    new THREE.MeshLambertMaterial({ color: 0xffffff }),
+    N,
+  );
+  canopies.castShadow = true;
+  const m4 = new THREE.Matrix4(),
+    col = new THREE.Color();
+  for (let i = 0; i < N; i++) {
+    const sx = Math.random() < 0.5 ? -1 : 1;
+    const x = sx * (22 + Math.pow(Math.random(), 1.6) * 70);
+    const z = -ROAD_HALF + Math.random() * ROAD_HALF * 2;
+    const h = 2.4 + Math.random() * 3.6; // 幹の高さ
+    const r = h * (0.42 + Math.random() * 0.22); // 樹冠の半径
+    m4.makeScale(1 + r * 0.3, h, 1 + r * 0.3).setPosition(x, 0, z);
+    trunks.setMatrixAt(i, m4);
+    m4.makeScale(r, r * (0.9 + Math.random() * 0.5), r).setPosition(x, h + r * 0.5, z);
+    canopies.setMatrixAt(i, m4);
+    col.setHSL(
+      0.26 + Math.random() * 0.09,
+      0.35 + Math.random() * 0.25,
+      0.26 + Math.random() * 0.14,
+    );
+    canopies.setColorAt(i, col);
+  }
+  scene.add(trunks, canopies);
+})();
+
+/* ---- 遠景: 山並み(霧の外に置く書割り) ---- */
+(function buildMountains() {
+  const far = new THREE.Mesh(new THREE.CylinderGeometry(860, 860, 180, 72, 1, true), mtnFarMat);
+  far.position.y = 66;
+  far.renderOrder = -16;
+  scene.add(far);
+  const near = new THREE.Mesh(new THREE.CylinderGeometry(760, 760, 130, 72, 1, true), mtnNearMat);
+  near.position.y = 40;
+  near.rotation.y = 2.1;
+  near.renderOrder = -15;
+  scene.add(near);
+})();
+
+/* ---- 雲 ---- */
+(function buildClouds() {
+  for (let i = 0; i < 9; i++) {
+    const th = Math.random() * Math.PI * 2,
+      R = 380 + Math.random() * 320;
+    const cx = Math.cos(th) * R,
+      cz = Math.sin(th) * R,
+      cy = 150 + Math.random() * 110;
+    for (let k = 0; k < 3; k++) {
+      // ひと塊を3枚のスプライトでもこもこに
+      const s = new THREE.Sprite(cloudMat);
+      const w = 90 + Math.random() * 120;
+      s.scale.set(w, w * (0.28 + Math.random() * 0.14), 1);
+      s.position.set(
+        cx + (Math.random() - 0.5) * 70,
+        cy + (Math.random() - 0.5) * 18,
+        cz + (Math.random() - 0.5) * 70,
+      );
+      s.renderOrder = -14;
+      scene.add(s);
+    }
+  }
+})();

--- a/src/render/theme.ts
+++ b/src/render/theme.ts
@@ -13,6 +13,9 @@ import {
   bulbMat,
   beamMat,
   signGlowMat,
+  mtnFarMat,
+  mtnNearMat,
+  cloudMat,
 } from './materials';
 import { nightGroup, nightDome } from './night';
 
@@ -31,6 +34,8 @@ export interface EnvSpec {
   tailIdle: number;
   lampEmissive: number;
   delin: number;
+  mtnFar: number;
+  mtnNear: number;
 }
 
 export const ENV: Record<'day' | 'night', EnvSpec> = {
@@ -49,6 +54,8 @@ export const ENV: Record<'day' | 'night', EnvSpec> = {
     tailIdle: 0x4a0b0b,
     lampEmissive: 0x000000,
     delin: 0x9aa3ad,
+    mtnFar: 0xb9cbd9,
+    mtnNear: 0x93aabf,
   },
   night: {
     bg: 0x141d33,
@@ -65,6 +72,8 @@ export const ENV: Record<'day' | 'night', EnvSpec> = {
     tailIdle: 0x7a1212,
     lampEmissive: 0xffc36b,
     delin: 0xffb054,
+    mtnFar: 0x101a2e,
+    mtnNear: 0x0b1322,
   },
 };
 
@@ -106,6 +115,9 @@ export function applyEnv(): void {
   lerpColor(glassMat.emissive, d.glassEmissive, n.glassEmissive, t);
   lerpColor(lampHeadMat.emissive, d.lampEmissive, n.lampEmissive, t);
   lerpColor(delinMat.color, d.delin, n.delin, t);
+  lerpColor(mtnFarMat.color, d.mtnFar, n.mtnFar, t);
+  lerpColor(mtnNearMat.color, d.mtnNear, n.mtnNear, t);
+  cloudMat.opacity = 0.9 * (1 - t); // 雲は夜には見えない
   _ca.setHex(d.tailIdle);
   _cb.setHex(n.tailIdle);
   themeState.tailIdleHex = _ca.lerp(_cb, t).getHex();

--- a/src/render/track.ts
+++ b/src/render/track.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { CONST as C } from '../core';
 import type { Section } from '../core';
 import { scene } from './scene';
-import { delinMat } from './materials';
+import { delinMat, asphaltTex } from './materials';
 
 const ROAD_HALF = C.ROAD_HALF;
 
@@ -15,16 +15,17 @@ export interface SectionTheme {
   title: string;
   sub: string;
 }
+// road はアスファルトテクスチャ(平均約0.73)と乗算されるため明るめに設定
 export const SECTION_THEME: Record<Section, SectionTheme> = {
   L: {
-    road: 0x3a463f,
+    road: 0x4d5c53,
     strip: 0x1fb46a,
     signBg: '#0d8c4d',
     title: '義務あり',
     sub: 'ゆずりあい区間',
   },
   R: {
-    road: 0x4a4238,
+    road: 0x60564a,
     strip: 0xf2a32b,
     signBg: '#c17a08',
     title: '義務なし',
@@ -32,14 +33,14 @@ export const SECTION_THEME: Record<Section, SectionTheme> = {
   },
 };
 
-/* ---- 道路(区間ごとに色味を変える) ---- */
+/* ---- 道路(アスファルト質感 + 区間ごとの色味) ---- */
 for (const [sec, cx] of [
   ['L', -7],
   ['R', 7],
 ] as [Section, number][]) {
   const road = new THREE.Mesh(
     new THREE.BoxGeometry(13.2, 0.12, ROAD_HALF * 2),
-    new THREE.MeshLambertMaterial({ color: SECTION_THEME[sec].road }),
+    new THREE.MeshLambertMaterial({ color: SECTION_THEME[sec].road, map: asphaltTex }),
   );
   road.position.set(cx, -0.06, 0);
   road.receiveShadow = true;
@@ -84,7 +85,7 @@ for (const [sec, sx] of [
     zc = (zTop + zEnd) / 2;
   const ramp = new THREE.Mesh(
     new THREE.BoxGeometry(3.6, 0.12, len),
-    new THREE.MeshLambertMaterial({ color: SECTION_THEME[sec].road }),
+    new THREE.MeshLambertMaterial({ color: SECTION_THEME[sec].road, map: asphaltTex }),
   );
   ramp.position.set(15 * sx, -0.055, zc);
   ramp.receiveShadow = true;

--- a/src/render/vehicle-mesh.ts
+++ b/src/render/vehicle-mesh.ts
@@ -4,10 +4,13 @@ import { CONST as C, clamp } from '../core';
 import type { Vehicle, World } from '../core';
 import { scene } from './scene';
 import {
-  lambert,
+  paint,
   glassMat,
   tireMat,
+  hubMat,
   cargoMat,
+  trimMat,
+  plateMat,
   headMat,
   brakeGlowMat,
   brakeGlowGeo,
@@ -15,6 +18,21 @@ import {
   beamGeo,
 } from './materials';
 import { themeState } from './theme';
+
+// ドライバーの「手癖」(描画上の個性)。実際の車は車線の中央ぴったりを走らない。
+// 車線内の定位置(左寄り/右寄り)、無意識の蛇行の周期・振幅、修正舵の細かさは
+// ドライバーごとに違う
+interface DriverHabit {
+  bias: number; // 好みの定位置(車線中央からのオフセット)
+  swayA: number; // 蛇行の振幅
+  f1: number; // ゆったりした蛇行 (rad/s)
+  f2: number; // さらに長周期のドリフト
+  f3: number; // 細かい修正舵
+  p1: number;
+  p2: number;
+  shaky: boolean; // 修正舵が忙しいタイプ
+  t: number;
+}
 
 export interface VehicleMesh {
   group: THREE.Group;
@@ -24,13 +42,47 @@ export interface VehicleMesh {
   beam: THREE.Mesh;
   bglow: THREE.Mesh;
   prevX: number;
+  prevSpeed: number;
+  pitch: number;
+  drv: DriverHabit;
 }
+
+// 車体の側面プロファイルを幅方向へ押し出し、実車らしいシルエットを作る。
+// プロファイルの +x が車体前方(ワールドの -z)、y が高さに対応する
+function profileGeo(pts: [number, number][], width: number, bevel: number): THREE.BufferGeometry {
+  const s = new THREE.Shape();
+  s.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 1; i < pts.length; i++) s.lineTo(pts[i][0], pts[i][1]);
+  const geo = new THREE.ExtrudeGeometry(s, {
+    depth: Math.max(0.1, width - bevel * 2),
+    bevelEnabled: true,
+    bevelThickness: bevel,
+    bevelSize: bevel,
+    bevelSegments: 2,
+  });
+  geo.translate(0, 0, -(width - bevel * 2) / 2);
+  geo.rotateY(Math.PI / 2);
+  return geo;
+}
+const wheelGeoCache: Record<string, THREE.CylinderGeometry> = {};
+function wheelGeo(r: number, w: number): THREE.CylinderGeometry {
+  const key = r + '_' + w;
+  if (!wheelGeoCache[key]) {
+    const geo = new THREE.CylinderGeometry(r, r, w, 14);
+    geo.rotateZ(Math.PI / 2); // 車軸をX方向へ
+    wheelGeoCache[key] = geo;
+  }
+  return wheelGeoCache[key];
+}
+const plateGeo = new THREE.BoxGeometry(0.34, 0.16, 0.04);
+const mirrorGeo = new THREE.BoxGeometry(0.1, 0.11, 0.2);
 
 function buildVehicleMesh(v: Vehicle): VehicleMesh {
   const t = v.type,
     L = t.len,
     W = t.w,
-    H = t.h;
+    H = t.h,
+    l = L / 2;
   const g = new THREE.Group();
   function add(
     geo: THREE.BufferGeometry,
@@ -46,79 +98,201 @@ function buildVehicleMesh(v: Vehicle): VehicleMesh {
     g.add(m);
     return m;
   }
-  const wx = W / 2 - 0.16,
-    wz = L / 2 - 0.95;
-  const wheelGeo = new THREE.BoxGeometry(0.32, 0.72, 0.8);
-  add(wheelGeo, tireMat, -wx, 0.36, -wz);
-  add(wheelGeo, tireMat, wx, 0.36, -wz);
-  add(wheelGeo, tireMat, -wx, 0.36, wz);
-  add(wheelGeo, tireMat, wx, 0.36, wz);
+  function wheels(r: number, wzs: number[]): void {
+    const wx = W / 2 - 0.14;
+    for (const wz of wzs)
+      for (const s of [-1, 1]) {
+        add(wheelGeo(r, 0.3), tireMat, s * wx, r, wz, true);
+        add(wheelGeo(r * 0.55, 0.34), hubMat, s * wx, r, wz);
+      }
+  }
+  function mirrors(mat: THREE.Material, y: number, z: number): void {
+    add(mirrorGeo, mat, -(W / 2 + 0.06), y, z);
+    add(mirrorGeo, mat, W / 2 + 0.06, y, z);
+  }
+  const body = paint(v.color);
 
-  const body = lambert(v.color);
   switch (v.typeName) {
     case 'Sedan': {
-      add(new THREE.BoxGeometry(W, H * 0.46, L), body, 0, 0.32 + H * 0.23, 0, true);
+      // 3ボックス(ボンネット・キャビン・トランク)の下半身
       add(
-        new THREE.BoxGeometry(W * 0.86, H * 0.42, L * 0.5),
-        glassMat,
+        profileGeo(
+          [
+            [-l, 0.32],
+            [-l, H * 0.62],
+            [-l * 0.93, H * 0.68],
+            [l * 0.55, H * 0.68],
+            [l * 0.82, H * 0.55],
+            [l, 0.62],
+            [l, 0.34],
+            [l * 0.9, 0.25],
+            [-l * 0.9, 0.25],
+          ],
+          W,
+          0.06,
+        ),
+        body,
         0,
-        0.32 + H * 0.66,
-        L * 0.05,
+        0,
+        0,
         true,
       );
+      // キャビン(スモークガラスのキャノピー)
+      add(
+        profileGeo(
+          [
+            [-l * 0.62, H * 0.64],
+            [-l * 0.4, H * 0.97],
+            [l * 0.06, H * 0.97],
+            [l * 0.34, H * 0.64],
+          ],
+          W * 0.84,
+          0.05,
+        ),
+        glassMat,
+        0,
+        0,
+        0,
+        true,
+      );
+      add(new THREE.BoxGeometry(0.1, 0.08, 0.26), body, 0, H * 0.99, l * 0.4); // シャークフィン
+      mirrors(body, H * 0.66, -l * 0.3);
+      wheels(0.33, [-(l - 0.85), l - 0.85]);
       if (v.isTaxi)
-        add(
-          new THREE.BoxGeometry(0.52, 0.24, 0.32),
-          lambert(0xffa400),
-          0,
-          0.32 + H * 0.9 + 0.12,
-          L * 0.05,
-        );
+        add(new THREE.BoxGeometry(0.5, 0.22, 0.3), paint(0xffa400), 0, H * 0.97 + 0.14, l * 0.15);
       break;
     }
     case 'SportsCar': {
-      add(new THREE.BoxGeometry(W, H * 0.55, L), body, 0, 0.28 + H * 0.275, 0, true);
+      // 低く長いウェッジシェイプ
       add(
-        new THREE.BoxGeometry(W * 0.8, H * 0.46, L * 0.42),
-        glassMat,
+        profileGeo(
+          [
+            [-l, 0.3],
+            [-l, H * 0.6],
+            [-l * 0.88, H * 0.72],
+            [-l * 0.15, H * 0.74],
+            [l * 0.55, H * 0.52],
+            [l, 0.44],
+            [l, 0.3],
+            [l * 0.9, 0.22],
+            [-l * 0.9, 0.22],
+          ],
+          W,
+          0.06,
+        ),
+        body,
         0,
-        0.28 + H * 0.77,
-        L * 0.04,
+        0,
+        0,
         true,
       );
-      add(new THREE.BoxGeometry(W * 0.95, 0.09, 0.5), body, 0, 0.28 + H * 0.86, L / 2 - 0.3, true);
+      add(
+        profileGeo(
+          [
+            [-l * 0.52, H * 0.66],
+            [-l * 0.26, H * 0.98],
+            [l * 0.04, H * 0.98],
+            [l * 0.3, H * 0.6],
+          ],
+          W * 0.78,
+          0.04,
+        ),
+        glassMat,
+        0,
+        0,
+        0,
+        true,
+      );
+      // リアウイング
+      add(new THREE.BoxGeometry(W * 0.92, 0.05, 0.36), body, 0, H * 0.92, l * 0.88, true);
+      add(new THREE.BoxGeometry(0.07, 0.2, 0.16), body, -W * 0.32, H * 0.79, l * 0.9);
+      add(new THREE.BoxGeometry(0.07, 0.2, 0.16), body, W * 0.32, H * 0.79, l * 0.9);
+      mirrors(body, H * 0.68, -l * 0.28);
+      wheels(0.33, [-(l - 0.8), l - 0.8]);
       break;
     }
     case 'Truck': {
-      const cabL = 2.3;
-      add(new THREE.BoxGeometry(W, 2.4, cabL), body, 0, 0.4 + 1.2, -(L / 2 - cabL / 2), true);
-      add(new THREE.BoxGeometry(W * 0.9, 0.9, 0.1), glassMat, 0, 1.95, -(L / 2 - 0.08));
+      const cabL = 2.2;
+      // キャブ
+      add(new THREE.BoxGeometry(W, 1.85, cabL), body, 0, 1.775, -(l - cabL / 2), true);
+      const tw = add(new THREE.BoxGeometry(W * 0.9, 0.85, 0.07), glassMat, 0, 2.3, -(l + 0.01));
+      tw.rotation.x = 0.1; // フロントガラスをわずかに寝かせる
+      add(new THREE.BoxGeometry(W + 0.02, 0.6, 1.0), glassMat, 0, 2.25, -(l - cabL / 2) + 0.1);
+      add(new THREE.BoxGeometry(W * 0.9, 0.55, 0.08), trimMat, 0, 1.35, -(l + 0.02)); // グリル
+      add(new THREE.BoxGeometry(W, 0.3, 0.14), hubMat, 0, 0.45, -(l + 0.03)); // 金属バンパー
+      // 導風板(キャブ屋根から荷箱の高さへつなぐ)
+      const defl = add(new THREE.BoxGeometry(W * 0.9, 1.45, 0.06), body, 0, 3.07, -(l - 1.55));
+      defl.rotation.x = 1.05;
+      // 荷箱
       add(
-        new THREE.BoxGeometry(W, H - 0.6, L - cabL - 0.35),
+        new THREE.BoxGeometry(W, H - 0.65, L - cabL - 0.35),
         cargoMat,
         0,
-        0.55 + (H - 0.6) / 2,
+        0.62 + (H - 0.65) / 2,
         (cabL + 0.35) / 2,
         true,
       );
+      add(new THREE.BoxGeometry(W * 0.94, 0.5, L * 0.3), trimMat, 0, 0.5, 0.1); // サイドスカート
+      add(new THREE.BoxGeometry(W * 0.9, 0.45, 0.05), trimMat, 0, 0.32, l - 0.15); // 泥除け
+      add(new THREE.BoxGeometry(W * 0.9, 0.12, 0.1), hubMat, 0, 0.55, l + 0.02); // 突入防止装置
+      mirrors(trimMat, 2.35, -(l - 0.25));
+      wheels(0.48, [-(l - 1.15), l - 1.35, l - 2.45]);
       break;
     }
     case 'Van': {
-      add(new THREE.BoxGeometry(W, H * 0.8, L), body, 0, 0.32 + H * 0.4, 0, true);
+      // ワンボックス
       add(
-        new THREE.BoxGeometry(W * 0.9, H * 0.34, 0.12),
+        profileGeo(
+          [
+            [-l, 0.34],
+            [-l, H * 0.92],
+            [-l * 0.86, H * 0.97],
+            [l * 0.26, H * 0.97],
+            [l * 0.6, H * 0.6],
+            [l, 0.42],
+            [l, 0.32],
+            [l * 0.9, 0.25],
+            [-l * 0.9, 0.25],
+          ],
+          W,
+          0.06,
+        ),
+        body,
+        0,
+        0,
+        0,
+        true,
+      );
+      // 傾斜したフロントガラス
+      const ws = add(
+        new THREE.BoxGeometry(W * 0.86, 1.15, 0.06),
         glassMat,
         0,
-        0.32 + H * 0.62,
-        -(L / 2 - 0.25),
+        H * 0.785,
+        -l * 0.43,
       );
+      ws.rotation.x = 0.86;
+      // サイドウィンドウ帯・リアガラス
+      add(new THREE.BoxGeometry(W + 0.02, H * 0.2, L * 0.55), glassMat, 0, H * 0.76, l * 0.18);
+      add(new THREE.BoxGeometry(W * 0.8, H * 0.22, 0.05), glassMat, 0, H * 0.72, l + 0.01);
+      mirrors(body, H * 0.62, -l * 0.42);
+      wheels(0.35, [-(l - 1.0), l - 1.1]);
       break;
     }
   }
+  // 樹脂バンパー・グリル・ナンバープレート(トラック以外の共通装備)
+  if (v.typeName !== 'Truck') {
+    add(new THREE.BoxGeometry(W * 0.98, 0.17, 0.12), trimMat, 0, 0.38, -(l + 0.01));
+    add(new THREE.BoxGeometry(W * 0.98, 0.17, 0.12), trimMat, 0, 0.38, l + 0.01);
+    add(new THREE.BoxGeometry(W * 0.5, 0.13, 0.05), trimMat, 0, 0.55, -(l + 0.04));
+  }
+  add(plateGeo, plateMat, 0, 0.4, -(l + 0.1));
+  add(plateGeo, plateMat, 0, 0.4, l + 0.1);
   // ヘッドライト（前方 = -Z）。マテリアルは全車共有で昼夜一括切替
+  const lightY = v.typeName === 'Truck' ? 1.05 : 0.66;
   const hGeo = new THREE.BoxGeometry(0.34, 0.16, 0.1);
-  add(hGeo, headMat, -(W / 2 - 0.34), 0.72, -L / 2 - 0.02);
-  add(hGeo, headMat, W / 2 - 0.34, 0.72, -L / 2 - 0.02);
+  add(hGeo, headMat, -(W / 2 - 0.34), lightY, -L / 2 - 0.06);
+  add(hGeo, headMat, W / 2 - 0.34, lightY, -L / 2 - 0.06);
   // ヘッドライトの路面照射(夜のみ表示)
   const beam = new THREE.Mesh(beamGeo, beamMat);
   beam.rotation.x = -Math.PI / 2;
@@ -129,22 +303,45 @@ function buildVehicleMesh(v: Vehicle): VehicleMesh {
   // 灯火類は照明の影響を受けない発光体として描く(昼でもはっきり光って見える)
   const brakeMat = new THREE.MeshBasicMaterial({ color: 0x4a0b0b });
   const bGeo = new THREE.BoxGeometry(0.52, 0.22, 0.1);
-  add(bGeo, brakeMat, -(W / 2 - 0.34), 0.74, L / 2 + 0.02);
-  add(bGeo, brakeMat, W / 2 - 0.34, 0.74, L / 2 + 0.02);
+  add(bGeo, brakeMat, -(W / 2 - 0.34), lightY + 0.06, L / 2 + 0.04);
+  add(bGeo, brakeMat, W / 2 - 0.34, lightY + 0.06, L / 2 + 0.04);
   // ウインカー（車線変更時に点滅）
   const blinkL = new THREE.MeshBasicMaterial({ color: 0x6b4a10 });
   const blinkR = new THREE.MeshBasicMaterial({ color: 0x6b4a10 });
   const kGeo = new THREE.BoxGeometry(0.22, 0.2, 0.22);
-  add(kGeo, blinkL, -(W / 2 + 0.02), 0.74, L / 2 - 0.12);
-  add(kGeo, blinkL, -(W / 2 + 0.02), 0.74, -(L / 2 - 0.12));
-  add(kGeo, blinkR, W / 2 + 0.02, 0.74, L / 2 - 0.12);
-  add(kGeo, blinkR, W / 2 + 0.02, 0.74, -(L / 2 - 0.12));
+  add(kGeo, blinkL, -(W / 2 + 0.02), lightY, L / 2 - 0.12);
+  add(kGeo, blinkL, -(W / 2 + 0.02), lightY, -(L / 2 - 0.12));
+  add(kGeo, blinkR, W / 2 + 0.02, lightY, L / 2 - 0.12);
+  add(kGeo, blinkR, W / 2 + 0.02, lightY, -(L / 2 - 0.12));
   // ブレーキ時に背面へにじむ赤いグロー(視認性アップ)
   const bglow = new THREE.Mesh(brakeGlowGeo, brakeGlowMat);
-  bglow.position.set(0, 0.72, L / 2 + 0.18);
+  bglow.position.set(0, lightY + 0.04, L / 2 + 0.18);
   bglow.visible = false;
   g.add(bglow);
-  return { group: g, brakeMat, blinkL, blinkR, beam, bglow, prevX: v.x };
+  const margin = Math.max(0, (3.7 - W) / 2 - 0.42); // 車線内で安全に振れる余白
+  const drv: DriverHabit = {
+    bias: (Math.random() * 2 - 1) * margin * 0.9,
+    swayA: (0.05 + Math.random() * 0.13) * Math.min(1, margin / 0.5 + 0.35),
+    f1: 0.55 + Math.random() * 0.55,
+    f2: 0.16 + Math.random() * 0.22,
+    f3: 2.2 + Math.random() * 1.6,
+    p1: Math.random() * 6.283,
+    p2: Math.random() * 6.283,
+    shaky: Math.random() < 0.22,
+    t: Math.random() * 100,
+  };
+  return {
+    group: g,
+    brakeMat,
+    blinkL,
+    blinkR,
+    beam,
+    bglow,
+    prevX: v.x + drv.bias,
+    prevSpeed: v.speed,
+    pitch: 0,
+    drv,
+  };
 }
 
 /* ---- ワールドとメッシュの同期 ---- */
@@ -160,10 +357,25 @@ export function syncMeshes(world: World, dt: number): void {
     }
     m.group.visible = !v.waiting;
     if (v.waiting) continue;
-    m.group.position.set(v.x, 0, v.z);
-    const latv = dt > 0 ? (v.x - m.prevX) / dt : 0;
-    m.prevX = v.x;
+    // ---- ハンドル操作の個性: 定位置のズレ + 無意識の蛇行(速度が低いほど収まる) ----
+    const d = m.drv;
+    d.t += dt;
+    const sway =
+      Math.sin(d.t * d.f1 + d.p1) * 0.62 +
+      Math.sin(d.t * d.f2 + d.p2) * 0.38 +
+      (d.shaky ? Math.sin(d.t * d.f3 + d.p1 * 2) * 0.22 : 0);
+    const amp = d.swayA * (0.25 + 0.75 * clamp(v.speed / 25, 0, 1));
+    const x = v.x + d.bias + sway * amp;
+    m.group.position.set(x, 0, v.z);
+    const latv = dt > 0 ? (x - m.prevX) / dt : 0;
+    m.prevX = x;
+    // 操舵ヨー + 車体ロール + 加減速のピッチ(ノーズダイブ/スクワット)
     m.group.rotation.y = clamp(-latv / (v.speed + 6), -0.16, 0.16) * 1.5;
+    m.group.rotation.z = m.group.rotation.y * 0.3;
+    const acc = dt > 0 ? (v.speed - m.prevSpeed) / dt : 0;
+    m.prevSpeed = v.speed;
+    m.pitch += (clamp(acc * 0.0075, -0.05, 0.03) - m.pitch) * Math.min(1, dt * 6);
+    m.group.rotation.x = m.pitch;
     m.beam.visible = themeState.mix > 0.04;
     m.brakeMat.color.setHex(v.braking ? 0xff2a2a : themeState.tailIdleHex);
     m.bglow.visible = v.braking;


### PR DESCRIPTION
- 車両: 側面プロファイル押し出しによる実車シルエット(セダン/スポーツ
  カー/バン/トラック)。光沢塗装・円筒ホイール・ミラー・グリル・
  バンパー・ナンバープレート・導風板などのディテールを追加
- 背景: 草地とアスファルト(骨材・轍・補修痕)のテクスチャ、遠景の
  山並み(昼夜で色が変わる書割り)、雲、並木(InstancedMesh)、
  ガードレール、遮音壁を追加
- 運転の個性: 車線中央ではなくドライバーごとの定位置(左寄り/右寄り)
  と無意識の蛇行(周期・振幅・修正舵の細かさに個人差)を描画に反映。
  加減速のピッチ(ノーズダイブ)と操舵ロールも追加
- シミュレーションロジック(sim-core)は無変更。テスト18件パス

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CcqyJqAdTTw4XDKVyymEgq