### PR TITLE
背景を並木から田んぼテクスチャに変更

### DIFF
--- a/src/render/materials.ts
+++ b/src/render/materials.ts
@@ -49,32 +49,70 @@ export const headMat = new THREE.MeshPhongMaterial({
 export const delinMat = new THREE.MeshBasicMaterial({ color: 0x9aa3ad }); // 視線誘導標
 export const lampHeadMat = new THREE.MeshLambertMaterial({ color: 0xd8d2b8, emissive: 0x000000 }); // 街灯灯具
 
-/* ---- 背景テクスチャ(草地・アスファルト) ---- */
-export function makeGrassTexture(): THREE.CanvasTexture {
+/* ---- 背景テクスチャ(田んぼ・アスファルト) ---- */
+export function makeRicePaddyTexture(): THREE.CanvasTexture {
+  // 2x2区画をひとつのタイルに描き、繰り返しても均一に見えないようにする
   const cv = document.createElement('canvas');
-  cv.width = cv.height = 256;
+  cv.width = cv.height = 512;
   const c2 = cv.getContext('2d')!;
-  c2.fillStyle = '#7c9a66';
-  c2.fillRect(0, 0, 256, 256);
-  // 濃淡のむら + 草の粒感
-  for (let i = 0; i < 2600; i++) {
-    const gr = 120 + Math.random() * 60;
-    c2.fillStyle =
-      'rgba(' +
-      Math.round(gr * 0.72) +
-      ',' +
-      Math.round(gr) +
-      ',' +
-      Math.round(gr * 0.52) +
-      ',' +
-      (0.08 + Math.random() * 0.16).toFixed(2) +
-      ')';
-    const s = 1 + Math.random() * 3;
-    c2.fillRect(Math.random() * 256, Math.random() * 256, s, s);
+  const CELL = 256;
+  for (let py = 0; py < 2; py++) {
+    for (let px = 0; px < 2; px++) {
+      const x0 = px * CELL,
+        y0 = py * CELL;
+      // 下地: 水と土がのぞく田面。区画ごとに明度を変え、田ごとの生育差を出す
+      const base = 92 + Math.random() * 30;
+      c2.fillStyle =
+        'rgb(' +
+        Math.round(base * 0.68) +
+        ',' +
+        Math.round(base) +
+        ',' +
+        Math.round(base * 0.6) +
+        ')';
+      c2.fillRect(x0, y0, CELL, CELL);
+      // 稲の条(すじ): 等間隔の植え付け列を粒で描く
+      for (let ry = 8; ry < CELL - 6; ry += 9) {
+        for (let rx = 5; rx < CELL - 5; rx += 6) {
+          const g = 115 + Math.random() * 70;
+          c2.fillStyle =
+            'rgba(' +
+            Math.round(g * 0.52) +
+            ',' +
+            Math.round(g) +
+            ',' +
+            Math.round(g * 0.4) +
+            ',' +
+            (0.55 + Math.random() * 0.35).toFixed(2) +
+            ')';
+          c2.fillRect(
+            x0 + rx + (Math.random() - 0.5) * 2,
+            y0 + ry + (Math.random() - 0.5) * 2,
+            3,
+            3,
+          );
+        }
+      }
+      // 畦(あぜ): 区画の縁を土色の帯で囲う(目立ちすぎないよう彩度低めに)
+      c2.fillStyle = 'rgba(140,130,95,0.8)';
+      c2.fillRect(x0, y0, CELL, 4);
+      c2.fillRect(x0, y0, 4, CELL);
+      c2.fillRect(x0, y0 + CELL - 4, CELL, 4);
+      c2.fillRect(x0 + CELL - 4, y0, 4, CELL);
+      // 畦の上の雑草
+      for (let i = 0; i < 90; i++) {
+        const onH = Math.random() < 0.5;
+        const t = Math.random() * CELL;
+        const edge = Math.random() < 0.5 ? 0 : CELL - 5;
+        c2.fillStyle = 'rgba(96,120,60,' + (0.2 + Math.random() * 0.3).toFixed(2) + ')';
+        if (onH) c2.fillRect(x0 + t, y0 + edge + Math.random() * 4, 2, 2);
+        else c2.fillRect(x0 + edge + Math.random() * 4, y0 + t, 2, 2);
+      }
+    }
   }
   const tex = new THREE.CanvasTexture(cv);
   tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-  tex.repeat.set(56, 56);
+  tex.repeat.set(28, 28); // 1区画 ≒ 28.6m四方
   return tex;
 }
 export function makeAsphaltTexture(): THREE.CanvasTexture {

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,6 +1,6 @@
 /* ================= Three.js セットアップ(シーン・カメラ・ライト) ================= */
 import * as THREE from 'three';
-import { makeGrassTexture } from './materials';
+import { makeRicePaddyTexture } from './materials';
 
 export const SKY = 0xcfe2ee;
 
@@ -40,10 +40,10 @@ sun.shadow.camera.far = 500;
 sun.shadow.bias = -0.0006;
 scene.add(sun);
 
-/* ---- 地面（草地。背景の透け防止のため広く・低く配置） ---- */
+/* ---- 地面（田んぼ。背景の透け防止のため広く・低く配置） ---- */
 const ground = new THREE.Mesh(
   new THREE.PlaneGeometry(1600, 1600),
-  new THREE.MeshLambertMaterial({ color: 0xffffff, map: makeGrassTexture() }),
+  new THREE.MeshLambertMaterial({ color: 0xffffff, map: makeRicePaddyTexture() }),
 );
 ground.rotation.x = -Math.PI / 2;
 ground.position.y = -0.18;

--- a/src/render/scenery.ts
+++ b/src/render/scenery.ts
@@ -1,5 +1,6 @@
-/* ================= 背景美術(路側・並木・遠景) =================
+/* ================= 背景美術(路側・遠景) =================
    道路施設(track.js)とは別の「風景」を担当する。
+   道路の外は scene.js の地面(田んぼテクスチャ)が広がる。
    山・雲のマテリアルは materials.js にあり、昼夜の色は theme.js が補間する */
 import * as THREE from 'three';
 import { CONST as C } from '../core';
@@ -54,45 +55,6 @@ const ROAD_HALF = C.ROAD_HALF;
       scene.add(p);
     }
   }
-})();
-
-/* ---- 並木・雑木林(InstancedMeshで軽量に大量配置) ---- */
-(function buildTrees() {
-  const N = 130;
-  const trunkGeo = new THREE.CylinderGeometry(0.1, 0.18, 1, 5);
-  trunkGeo.translate(0, 0.5, 0);
-  const canopyGeo = new THREE.IcosahedronGeometry(1, 0);
-  const trunks = new THREE.InstancedMesh(
-    trunkGeo,
-    new THREE.MeshLambertMaterial({ color: 0x6b4e35 }),
-    N,
-  );
-  const canopies = new THREE.InstancedMesh(
-    canopyGeo,
-    new THREE.MeshLambertMaterial({ color: 0xffffff }),
-    N,
-  );
-  canopies.castShadow = true;
-  const m4 = new THREE.Matrix4(),
-    col = new THREE.Color();
-  for (let i = 0; i < N; i++) {
-    const sx = Math.random() < 0.5 ? -1 : 1;
-    const x = sx * (22 + Math.pow(Math.random(), 1.6) * 70);
-    const z = -ROAD_HALF + Math.random() * ROAD_HALF * 2;
-    const h = 2.4 + Math.random() * 3.6; // 幹の高さ
-    const r = h * (0.42 + Math.random() * 0.22); // 樹冠の半径
-    m4.makeScale(1 + r * 0.3, h, 1 + r * 0.3).setPosition(x, 0, z);
-    trunks.setMatrixAt(i, m4);
-    m4.makeScale(r, r * (0.9 + Math.random() * 0.5), r).setPosition(x, h + r * 0.5, z);
-    canopies.setMatrixAt(i, m4);
-    col.setHSL(
-      0.26 + Math.random() * 0.09,
-      0.35 + Math.random() * 0.25,
-      0.26 + Math.random() * 0.14,
-    );
-    canopies.setColorAt(i, col);
-  }
-  scene.add(trunks, canopies);
 })();
 
 /* ---- 遠景: 山並み(霧の外に置く書割り) ---- */


### PR DESCRIPTION
3Dの木(InstancedMeshの並木)は視覚的に違和感があったため削除し、
地面テクスチャを草地から田園風景(稲の条・畦で区切られた区画)に
置き換えた。区画ごとに明度を変えて繰り返しの均一感を抑えている。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012cknhSQyvUpnk1XjYYrNaP