### PR TITLE
追いつかれた時の加速復帰: 塞がれた復帰先へ加速して前に出て戻る挙動を追加

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -28,6 +28,13 @@ export const CONST = {
   CAMPER_RETURN_TIME_MAX: 35,
   CAMPER_RATIO: 0.7, // 義務なし区間: 譲らない人のうちマイペース派の割合
   VOLUNTARY_YIELD_RATIO: 0.15, // 義務なし区間でも自発的に譲る人の割合
+  // ---- 加速復帰: 復帰先が並走車に塞がれている時、加速して前に出て戻る ----
+  RETURN_BOOST_MAX_SPEED_DIFF: 2.5, // 並走車との速度差がこれ未満なら「加速すれば抜ける」と判断 (m/s)
+  RETURN_BOOST_TARGET_CLEARANCE: 35, // 並走車の前方にこれ以上の空きがあれば「前に出れば戻れる」見込みあり (m)
+  RETURN_BOOST_AHEAD_CLEARANCE: 30, // 自車線前方にこれ以上の空きがなければ加速しない (m)
+  RETURN_BOOST_SPEED_DELTA: 2.5, // 加速復帰中に希望速度へ上乗せする加速量の上限 (m/s)
+  RETURN_BOOST_DURATION: 6.0, // 加速して前に出ることを試みる時間 (s)
+  RETURN_BOOST_RETRY_COOLDOWN: 8.0, // 加速しても抜けなかった後、再挑戦するまでの間 (s)
   REF_SPEED: 25, // スコア算出の基準速度 (m/s ≒ 90km/h)
   SCORE_W_SPEED: 0.75,
   SCORE_W_DENSITY: 0.25,

--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -216,9 +216,8 @@ export class Vehicle {
   // 見込みがある」なら一時的に加速して並走車を抜き、車線復帰を狙う
   tryStartReturnBoost(ahead: NeighborInfo | null): boolean {
     const C = CONST;
-    // 「後続のために加速してでも戻る」のは追いつかれた車両の義務がある区間の
-    // 文化(塞がれた時に減速して後ろへ入る工夫と同じく、義務を果たすための行動)
-    if (this.section !== 'L' || !this.yields) return false;
+    // ロジックは左右共通。区間差は「戻ろうとする早さ」(returnTime = 義務の有無に
+    // 由来する気質)からのみ生まれ、この判定自体は両区間とも同じ条件で発動する。
     // 流れが悪い時に加速すると自分がブレーキ連鎖の起点になる。ほぼ自分の
     // ペースで走れている(=本当に並走車だけが障害)時に限って踏み込む
     if (this.speed < this.desiredSpeed * 0.85) return false;

--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -75,6 +75,8 @@ export class Vehicle {
   slowAheadT: number;
   noiseAmp: number;
   keepRightT = 0; // マイペース派が追い越し車線へ戻るまでの計時
+  returnBoostT = 0; // 加速復帰(塞がれた復帰先の並走車を抜くための一時加速)の残り時間
+  returnBoostCd = 0; // 加速復帰を諦めた後の再挑戦クールダウン
 
   constructor(
     world: World,
@@ -191,6 +193,54 @@ export class Vehicle {
         return true;
     }
     return false;
+  }
+
+  // 復帰先車線で自分の真横(±車体+8m)を占有し、車線変更を物理的に塞ぐ並走車を返す
+  findAlongside(lane: number): Vehicle | null {
+    const arr = this.world._sec[this.section];
+    let best: Vehicle | null = null,
+      bestD = Infinity;
+    for (const v of arr) {
+      if (v === this || !v.occupies(lane)) continue;
+      const d = Math.abs(wrapDelta(v.z - this.z));
+      if (d < (this.length + v.length) / 2 + 8 && d < bestD) {
+        bestD = d;
+        best = v;
+      }
+    }
+    return best;
+  }
+
+  // 加速復帰の開始判定: 追い越し車線で後続に追いつかれ、復帰先(レーン1)が並走車に
+  // 塞がれている時、「速度差が小さく、並走車の前方が空いていて前に出れば戻れる
+  // 見込みがある」なら一時的に加速して並走車を抜き、車線復帰を狙う
+  tryStartReturnBoost(ahead: NeighborInfo | null): boolean {
+    const C = CONST;
+    // 「後続のために加速してでも戻る」のは追いつかれた車両の義務がある区間の
+    // 文化(塞がれた時に減速して後ろへ入る工夫と同じく、義務を果たすための行動)
+    if (this.section !== 'L' || !this.yields) return false;
+    // 流れが悪い時に加速すると自分がブレーキ連鎖の起点になる。ほぼ自分の
+    // ペースで走れている(=本当に並走車だけが障害)時に限って踏み込む
+    if (this.speed < this.desiredSpeed * 0.85) return false;
+    // (a) 明確に速い後続に追いつかれている(=どいてあげたい動機がある)時だけ
+    //     発動する(閾値は「追いつかれた車両の義務」の譲り判定と同一)
+    const behind = this.findBehind(this.lane);
+    if (!behind) return false;
+    const rel = behind.v.speed - this.speed;
+    if (rel < 2.5 || behind.gap > 24 + rel * 4.5) return false;
+    // (b) 復帰先を並走車が塞いでおり、待っていても抜けず(相手が同速以上)、
+    //     かつ速度差が小さい(少し加速すれば前に出られる)
+    const side = this.findAlongside(1);
+    if (!side) return false;
+    const sideRel = side.speed - this.speed;
+    if (sideRel < -0.5 || sideRel > C.RETURN_BOOST_MAX_SPEED_DIFF) return false;
+    // (c) 並走車の前方に空きがあり、前に出れば戻るスペースができる見込みがある
+    const sideAhead = side.findAhead(1);
+    if (sideAhead && sideAhead.gap < C.RETURN_BOOST_TARGET_CLEARANCE) return false;
+    // (d) 自車線の前方にも加速の余地がある(前が詰まっているのに踏まない)
+    if (ahead && ahead.gap < C.RETURN_BOOST_AHEAD_CLEARANCE + this.speed * 0.5) return false;
+    this.returnBoostT = C.RETURN_BOOST_DURATION;
+    return true;
   }
 
   // 前方車探索（z昇順インデックスを利用。ahead = z が小さい側。周回路として探索）
@@ -445,8 +495,15 @@ export class Vehicle {
       if (!slowAhead) this.returnTimer += dt;
       else this.returnTimer = 0;
       if (this.returnTimer > this.returnTime && flowing) {
-        if (this.tryLaneChange(1)) this.returnTimer = 0;
-        else if (this.section === 'L' && this.hasDeadlockAlongside(1)) this.yieldSlowT = 1.0;
+        if (this.tryLaneChange(1)) {
+          this.returnTimer = 0; // 加速中なら残り時間だけ速度を維持したまま戻る
+        } else if (this.returnBoostT <= 0) {
+          // 復帰先が塞がっている: まず「加速して並走車の前に出て戻る」を試み、
+          // 見込みがなければ従来どおり少し減速して並走車の後ろに入る
+          if (this.returnBoostCd > 0 || !this.tryStartReturnBoost(ahead)) {
+            if (this.section === 'L' && this.hasDeadlockAlongside(1)) this.yieldSlowT = 1.0;
+          }
+        }
       }
       this.keepLeftTimer = 0;
     } else if (this.keepLeft && flowing && this.lane === 1) {
@@ -477,6 +534,16 @@ export class Vehicle {
     this.cooldown = Math.max(0, this.cooldown - dt);
     this.noOvertakeT = Math.max(0, this.noOvertakeT - dt);
     this.yieldSlowT = Math.max(0, this.yieldSlowT - dt);
+    this.returnBoostCd = Math.max(0, this.returnBoostCd - dt);
+    if (this.returnBoostT > 0) {
+      this.returnBoostT -= dt;
+      // 復帰(車線変更)開始後もタイマーが切れるまでは速度を維持し、元の並走車
+      // (=戻った先の後続)との車間を開けてから元のペースへ戻す(急な割り込みで
+      // 後続にブレーキを踏ませ、渋滞波の起点になるのを防ぐ)
+      if (this.returnBoostT <= 0 && this.lane === 0 && this.lc.state === 'none') {
+        this.returnBoostCd = C.RETURN_BOOST_RETRY_COOLDOWN; // 抜けなかったので一旦諦める
+      }
+    }
     this.updateLaneChange(dt);
 
     // --- 衝突回避: 前方車両追従 ---
@@ -508,6 +575,9 @@ export class Vehicle {
     if (isAbsorbMode && this.z > CONST.SAG_Z_MIN && this.z < CONST.SAG_Z_MAX) {
       desire *= this.absorber ? CONST.SAG_SLOWDOWN_ABSORBER : CONST.SAG_SLOWDOWN;
     }
+    // 加速復帰中は希望速度を一時的に上乗せして並走車の前に出る(上限 RETURN_BOOST_SPEED_DELTA)。
+    // 前方車への追従・緊急ブレーキはこの後の通常ロジックがそのまま制限するため安全は保たれる
+    if (this.returnBoostT > 0) desire += CONST.RETURN_BOOST_SPEED_DELTA;
     let ts = this.yieldSlowT > 0 ? Math.max(8, desire - 2.5) : desire;
     // 加速車線: 終端で止まれる速度に常に制限(合流できなければ端で待つ)
     if (this.lane === 3 || (this.lc.state !== 'none' && this.lc.from === 3 && this.lc.t < 0.5)) {

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -199,51 +199,68 @@ describe('追い越し', () => {
    ============================================================ */
 describe('加速復帰（追いつかれ時に並走車を抜いて戻る）', () => {
   // 共通シナリオ: 追い越し車線の a が後続の chaser に追いつかれ、復帰先の
-  // レーン1は並走車 side に塞がれている。blocker は side のキープレフトを封じる
-  function setup(sideAheadBlocked: boolean) {
+  // レーン1は並走車 side に塞がれている。ロジックは左右共通(区間差は
+  // returnTime のみ)なので、両区間で同じ挙動になることを検証する
+  function setup(sec: 'L' | 'R', sideAheadBlocked: boolean) {
     const w = new World({ rng: createRng(9), spawnInterval: 1e9 });
-    const a = new Vehicle(w, 'L', 0, 0, 'Sedan', 25);
+    const a = new Vehicle(w, sec, 0, 0, 'Sedan', 25);
     a.speed = 25;
-    const side = new Vehicle(w, 'L', 1, 0, 'Sedan', 25); // 同速の並走車 = 待っても抜けない
+    // 義務なし区間は「戻る気になるまで」が長いだけでロジックは同じ。
+    // 戻る気になった後の挙動を比較するため復帰判定時間を揃える
+    a.returnTime = CONST.OVERTAKE_LANE_RETURN_TIME;
+    const side = new Vehicle(w, sec, 1, 0, 'Sedan', 25); // 同速の並走車 = 待っても抜けない
     side.speed = 25;
-    const blocker = new Vehicle(w, 'L', 2, -18, 'Truck', 16);
-    blocker.speed = 16;
-    const chaser = new Vehicle(w, 'L', 0, 55, 'SportsCar', 34);
+    side.keepLeft = false; // side がレーン移動して前方が空いてしまうのを防ぐ
+    side.camper = false;
+    const chaser = new Vehicle(w, sec, 0, 55, 'SportsCar', 34);
     chaser.speed = 32;
-    w.vehicles.push(a, side, blocker, chaser);
+    w.vehicles.push(a, side, chaser);
     if (sideAheadBlocked) {
       // side の前方を塞ぎ「前に出ても戻るスペースがない」状況にする
-      const wall = new Vehicle(w, 'L', 1, -22, 'Sedan', 24.5);
+      const wall = new Vehicle(w, sec, 1, -22, 'Sedan', 24.5);
       wall.speed = 24.5;
-      wall.keepLeft = false; // wall がレーン2へ逸れて前方が空いてしまうのを防ぐ
+      wall.keepLeft = false; // wall がレーン移動して前方が空いてしまうのを防ぐ
+      wall.camper = false;
       w.vehicles.push(wall);
     }
     return { w, a, side };
   }
 
-  test('並走車との速度差が小さく前方が空いていれば、加速して前に出て復帰する', () => {
-    const { w, a } = setup(false);
-    let boosted = false,
-      returned = false;
-    for (let i = 0; i < Math.round(25 / DT); i++) {
-      w.step(DT);
-      if (a.returnBoostT > 0) boosted = true;
-      if (a.lane === 1 || (a.lc.state !== 'none' && a.lc.to === 1)) {
-        returned = true;
-        break;
+  test.each([
+    ['義務あり', 'L'],
+    ['義務なし', 'R'],
+  ] as const)(
+    '%s区間: 並走車との速度差が小さく前方が空いていれば、加速して前に出て復帰する',
+    (_name, sec) => {
+      const { w, a } = setup(sec, false);
+      let boosted = false,
+        returned = false;
+      for (let i = 0; i < Math.round(25 / DT); i++) {
+        w.step(DT);
+        if (a.returnBoostT > 0) boosted = true;
+        if (a.lane === 1 || (a.lc.state !== 'none' && a.lc.to === 1)) {
+          returned = true;
+          break;
+        }
       }
-    }
-    expect(boosted, '加速復帰(returnBoostT)が発動しなかった').toBe(true);
-    expect(returned, '加速しても走行車線へ復帰できなかった').toBe(true);
-  });
+      expect(boosted, '加速復帰(returnBoostT)が発動しなかった').toBe(true);
+      expect(returned, '加速しても走行車線へ復帰できなかった').toBe(true);
+    },
+  );
 
-  test('並走車の前方が塞がっている(戻る見込みがない)場合は加速しない', () => {
-    const { w, a } = setup(true);
-    for (let i = 0; i < Math.round(10 / DT); i++) {
-      w.step(DT);
-      expect(a.returnBoostT, '見込みがないのに加速復帰が発動した').toBe(0);
-    }
-  });
+  test.each([
+    ['義務あり', 'L'],
+    ['義務なし', 'R'],
+  ] as const)(
+    '%s区間: 並走車の前方が塞がっている(戻る見込みがない)場合は加速しない',
+    (_name, sec) => {
+      const { w, a } = setup(sec, true);
+      for (let i = 0; i < Math.round(10 / DT); i++) {
+        w.step(DT);
+        expect(a.returnBoostT, '見込みがないのに加速復帰が発動した').toBe(0);
+      }
+    },
+  );
 });
 
 /* ============================================================

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -195,6 +195,58 @@ describe('追い越し', () => {
 });
 
 /* ============================================================
+   3.5 加速復帰: 追いつかれた時、塞がれた復帰先へ加速して戻る (Issue #11)
+   ============================================================ */
+describe('加速復帰（追いつかれ時に並走車を抜いて戻る）', () => {
+  // 共通シナリオ: 追い越し車線の a が後続の chaser に追いつかれ、復帰先の
+  // レーン1は並走車 side に塞がれている。blocker は side のキープレフトを封じる
+  function setup(sideAheadBlocked: boolean) {
+    const w = new World({ rng: createRng(9), spawnInterval: 1e9 });
+    const a = new Vehicle(w, 'L', 0, 0, 'Sedan', 25);
+    a.speed = 25;
+    const side = new Vehicle(w, 'L', 1, 0, 'Sedan', 25); // 同速の並走車 = 待っても抜けない
+    side.speed = 25;
+    const blocker = new Vehicle(w, 'L', 2, -18, 'Truck', 16);
+    blocker.speed = 16;
+    const chaser = new Vehicle(w, 'L', 0, 55, 'SportsCar', 34);
+    chaser.speed = 32;
+    w.vehicles.push(a, side, blocker, chaser);
+    if (sideAheadBlocked) {
+      // side の前方を塞ぎ「前に出ても戻るスペースがない」状況にする
+      const wall = new Vehicle(w, 'L', 1, -22, 'Sedan', 24.5);
+      wall.speed = 24.5;
+      wall.keepLeft = false; // wall がレーン2へ逸れて前方が空いてしまうのを防ぐ
+      w.vehicles.push(wall);
+    }
+    return { w, a, side };
+  }
+
+  test('並走車との速度差が小さく前方が空いていれば、加速して前に出て復帰する', () => {
+    const { w, a } = setup(false);
+    let boosted = false,
+      returned = false;
+    for (let i = 0; i < Math.round(25 / DT); i++) {
+      w.step(DT);
+      if (a.returnBoostT > 0) boosted = true;
+      if (a.lane === 1 || (a.lc.state !== 'none' && a.lc.to === 1)) {
+        returned = true;
+        break;
+      }
+    }
+    expect(boosted, '加速復帰(returnBoostT)が発動しなかった').toBe(true);
+    expect(returned, '加速しても走行車線へ復帰できなかった').toBe(true);
+  });
+
+  test('並走車の前方が塞がっている(戻る見込みがない)場合は加速しない', () => {
+    const { w, a } = setup(true);
+    for (let i = 0; i < Math.round(10 / DT); i++) {
+      w.step(DT);
+      expect(a.returnBoostT, '見込みがないのに加速復帰が発動した').toBe(0);
+    }
+  });
+});
+
+/* ============================================================
    4. 安全性: 車両の貫通防止
    ============================================================ */
 describe('衝突回避・貫通防止', () => {


### PR DESCRIPTION
Closes #11

## 概要

追い越し車線で速い後続車に追いつかれ、走行車線へ戻りたいのに並走車に塞がれている時、従来は戻るのを諦める(義務あり区間では減速して後ろに入る)だけでした。本PRでは Issue #11 の要望どおり、**並走車との速度差が小さく、かつその前方が空いていて前に出れば戻れる見込みがある場合、一時的に加速して並走車を抜き、車線復帰を狙う**挙動を追加します。

## 発動条件(`Vehicle.tryStartReturnBoost`)— 左右共通

判定ロジックは両区間で完全に共通です。区間差は「追いつかれた車両の義務」に由来する復帰の早さ(`returnTime`: 義務あり1.8秒 / 義務なし9〜35秒)からのみ自然に生まれます。

1. ほぼ自分のペース(希望速度の85%以上)で走れていること — 流れが悪い時に加速すると自分がブレーキ連鎖の起点になるため
2. 明確に速い後続に追いつかれていること(速度差 2.5 m/s 超・接近距離は既存の譲り判定と同一の閾値)
3. 復帰先を塞ぐ並走車との速度差が -0.5〜+2.5 m/s(`RETURN_BOOST_MAX_SPEED_DIFF`)— 「少し加速すれば前に出られる」帯域
4. 並走車の前方に 35m 以上の空き(`RETURN_BOOST_TARGET_CLEARANCE`)— 前に出れば戻るスペースができる見込み
5. 自車線の前方にも加速の余地(`RETURN_BOOST_AHEAD_CLEARANCE` + 速度比例分)

## 挙動

- 発動中は希望速度に +2.5 m/s(`RETURN_BOOST_SPEED_DELTA`)を上乗せ。**前方車への追従サーボ・緊急ブレーキは従来の安全ロジックがそのまま優先される**ため、衝突安全性は変わりません(貫通防止テストも従来どおり通過)
- 復帰の車線変更を開始した後もタイマー(6秒)が切れるまで速度を維持し、元の並走車(=戻った先の後続)との車間を開けてから元のペースへ戻る — 急な割り込みで後続にブレーキを踏ませて渋滞波の起点になるのを防ぐ
- 抜けられなかった場合は 8 秒のクールダウン(`RETURN_BOOST_RETRY_COOLDOWN`)後に再挑戦し、その間は従来どおり減速して後ろに入るフォールバック(義務あり区間の既存挙動)が働く

## 閾値の根拠

各閾値は `constants.ts` の `RETURN_BOOST_*` として定義し、パラメータ調整室からも変更可能です。値は「新挙動が発動する場面を『並走車だけが障害』の状況に絞り、L/R 両区間の渋滞スコア差(約10ポイント)という本シミュレーションの核心の比較を崩さない」ことを条件に、5シードのスコア計測を繰り返して決定しました(最終値でスコア差: 9.9 / 14.5 / 8.8 / 10.8 / 7.1、平均 10.2)。

## テスト

- 新挙動のテストを4件追加(`test.each` で両区間を同一シナリオで検証し、ロジックが左右共通であることを担保):
  - 並走車との速度差が小さく前方が空いていれば、加速(`returnBoostT` 発動)して走行車線へ復帰する(L/R)
  - 並走車の前方が塞がっている(戻る見込みがない)場合は加速しない(L/R)
- `pnpm check`: pass(フォーマット・lint・型エラーなし)
- `pnpm test`: 22/22 pass(渋滞スコア差・貫通防止・既存挙動テストすべて通過)

## 変更ファイル

- `src/core/constants.ts`: `RETURN_BOOST_*` 定数6件を追加
- `src/core/vehicle.ts`: `findAlongside` / `tryStartReturnBoost` を追加し、復帰判定(`decide`)と速度制御(`update`)に加速復帰を組み込み
- `traffic-simulation.test.ts`: 新挙動のテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)