### PR TITLE
ナイトモードでパネルが暗くなる演出を削除

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -42,7 +42,6 @@ canvas {
   box-shadow:
     0 8px 22px rgba(0, 30, 20, 0.4),
     inset 0 1px 0 rgba(255, 255, 255, 0.25);
-  transition: filter 0.9s ease;
 }
 .sign.amber {
   background: linear-gradient(180deg, #d1860c 0%, #965c03 100%);
@@ -50,14 +49,9 @@ canvas {
     0 8px 22px rgba(40, 25, 0, 0.4),
     inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
-/* 夜は標識の照明を落とす(計器盤のような減光) */
-body.night .sign {
-  filter: brightness(0.62) saturate(0.92);
-}
 @media (prefers-reduced-motion: reduce) {
   html,
-  body,
-  .sign {
+  body {
     transition: none;
   }
 }


### PR DESCRIPTION
Closes #10

## 変更内容

ナイトモード切替時に、標識風のUIパネル(左上の操作パネル・下部のスコア比較パネル・パラメータ調整室モーダル)へ `filter: brightness(0.62) saturate(0.92)` を掛けて減光していた演出を削除しました。昼夜どちらでもパネルは同じ明るさで表示されます。

- `body.night .sign { filter: ... }` ルールを削除
- 減光のクロスフェード専用だった `.sign` の `transition: filter 0.9s ease` と、`prefers-reduced-motion` メディアクエリ内の `.sign` 除外指定も併せて削除

3Dシーン側の夜演出(夜空・星・月・街灯・ヘッドライトの光だまりなど)と、ナイトモード切替ボタン自体の外観、ページ背景色の切替には手を入れていません。

## 確認

- ブラウザで昼→夜を切り替え、`getComputedStyle` で両パネルの `filter` が常に `none` であること、スクリーンショットで昼夜のパネルの明るさが同一であることを確認
- `pnpm check`: pass(フォーマット・lint・型エラーなし)
- `pnpm test`: 18件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)