### PR TITLE
バンの見た目をハイエース風のキャブオーバー形状に変更

### DIFF
--- a/src/render/vehicle-mesh.ts
+++ b/src/render/vehicle-mesh.ts
@@ -320,11 +320,11 @@ function buildBlueprint(typeName: VehicleTypeName): Blueprint {
         profileGeometry(
           [
             [-halfLength, 0.34],
-            [-halfLength, bodyHeight * 0.92],
-            [-halfLength * 0.86, bodyHeight * 0.97],
-            [halfLength * 0.26, bodyHeight * 0.97],
-            [halfLength * 0.6, bodyHeight * 0.6],
-            [halfLength, 0.42],
+            [-halfLength, bodyHeight * 0.84],
+            [-halfLength * 0.9, bodyHeight * 0.96],
+            [halfLength * 0.72, bodyHeight * 0.96],
+            [halfLength * 0.96, bodyHeight * 0.82],
+            [halfLength, 0.58],
             [halfLength, 0.32],
             [halfLength * 0.9, 0.25],
             [-halfLength * 0.9, 0.25],
@@ -336,22 +336,30 @@ function buildBlueprint(typeName: VehicleTypeName): Blueprint {
         0,
         0,
       );
-      // 傾斜したフロントガラス
+      // キャブオーバーらしく、前面のすぐ上に立ったフロントガラス
       put(
         'glass',
-        new THREE.BoxGeometry(bodyWidth * 0.86, 1.15, 0.06),
+        new THREE.BoxGeometry(bodyWidth * 0.86, bodyHeight * 0.3, 0.06),
         0,
-        bodyHeight * 0.785,
-        -halfLength * 0.43,
-        0.86,
+        bodyHeight * 0.76,
+        -(halfLength + 0.02),
+        0.08,
+      );
+      // ボンネットの代わりの低いグリル
+      put(
+        'trim',
+        new THREE.BoxGeometry(bodyWidth * 0.8, bodyHeight * 0.16, 0.06),
+        0,
+        bodyHeight * 0.5,
+        -(halfLength + 0.03),
       );
       // サイドウィンドウ帯・リアガラス
       put(
         'glass',
-        new THREE.BoxGeometry(bodyWidth + 0.02, bodyHeight * 0.2, bodyLength * 0.55),
+        new THREE.BoxGeometry(bodyWidth + 0.02, bodyHeight * 0.22, bodyLength * 0.58),
         0,
-        bodyHeight * 0.76,
-        halfLength * 0.18,
+        bodyHeight * 0.78,
+        halfLength * 0.12,
       );
       put(
         'glass',
@@ -360,8 +368,8 @@ function buildBlueprint(typeName: VehicleTypeName): Blueprint {
         bodyHeight * 0.72,
         halfLength + 0.01,
       );
-      mirrors('body', bodyHeight * 0.62, -halfLength * 0.42);
-      wheels(0.35, [-(halfLength - 1.0), halfLength - 1.1]);
+      mirrors('body', bodyHeight * 0.68, -(halfLength - 0.22));
+      wheels(0.35, [-(halfLength - 0.75), halfLength - 1.1]);
       break;
     }
   }


### PR DESCRIPTION
## 概要

Issue #21 で報告された、バンの前方で窓とボンネットが斜めにつながり現実に無さそうな見た目になっている問題を修正します。

ハイエース / ボンゴのような日本のキャブオーバー型ワンボックスのシルエットになるよう、`src/render/vehicle-mesh.ts` の `case 'Van':` のジオメトリのみを変更しました。

## 変更内容

- **フロントガラスを立てて前面へ移動**: 車体中央寄り (`-halfLength * 0.43`) で大きく傾いていた (`rotationX = 0.86`) ガラスを、前面バンパーの真上 (`-(halfLength + 0.02)`) にほぼ垂直 (`rotationX = 0.08`) で配置。これにより窓とボンネットが斜めにつながる形状を解消
- **ボンネットを廃し低いグリルに置き換え**: 前面下部に低いグリルパネル (`trim`) を追加
- **キャブを前輪上へ**: 前輪位置を前方へ (`-(halfLength - 1.0)` → `-(halfLength - 0.75)`)、ミラーも前方へ (`-halfLength * 0.42` → `-(halfLength - 0.22)`)
- **背の高い箱型ボディ**: ルーフ稜線を後方まで伸ばし (`halfLength * 0.26` → `halfLength * 0.72`)、ワンボックスらしい直方体に近い側面プロファイルへ変更

## 影響範囲

- 変更は `src/render/vehicle-mesh.ts` の Van 分岐のみ。他の車種のジオメトリ・シミュレーションロジック (`src/core/**`)・テストには一切触れていません
- 車体の全長 / 全幅は据え置きで、シミュレーション側の前提を変えていません

## 検証

```
$ pnpm test
 Test Files  5 passed (5)
      Tests  143 passed (143)

$ pnpm check
pass: All 161 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 123 files
```

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)