### PR TITLE
追い越し車線を両区間とも右側に統一 (Issue #28)

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -9,6 +9,18 @@ export type Section = 'L' | 'R';
 /** シミュレーションモード。'rules' = ルール比較 / 'absorb' = 渋滞吸収運転 */
 export type SimMode = 'rules' | 'absorb';
 
+/* ---------------- 区間の横方向レイアウト ----------------
+   両区間とも進行方向は -Z(前方 = z が小さい側)なので、進行方向を向いた時の
+   「右」は +X 側になる。R区間をL区間の鏡像にすると R の追い越し車線だけが
+   左側に来てしまうため、R区間は鏡像ではなく「L区間の平行移動コピー」にする。
+   これで両区間とも 追い越し車線 = 右端 / 加速車線 = 左外側 に揃い、
+   合流の条件も鏡像ではなく完全に同一になる。 */
+
+/** L区間 → R区間 の平行移動量(この分だけ +X 側にずらす) */
+const SECTION_OFFSET_R_X = 17.2;
+/** L区間の車線中心X。index 0 = 追い越し(右端) 〜 2 = 走行車線(左端), 3 = 加速車線(左外側) */
+const LANE_X_L = [-3, -7, -11, -15];
+
 /* ---------------- 定数 ---------------- */
 export const CONST = {
   ROAD_HALF: 400, // 道路は Z = -400 ～ +400
@@ -21,7 +33,10 @@ export const CONST = {
   EXIT_RATIO: 0.08, // 終端の出口で流出する車の割合(残りは環状線のように周回)
   INFLOW_PACE: 10.4, // 生成間隔→流入間隔の換算係数(流出率とつり合う需要に換算)
   MAX_PER_SECTION: 140,
-  LANE_X: { L: [-3, -7, -11, -15], R: [3, 7, 11, 15] }, // index 0 = 追い越し(中央寄り), 3 = 加速車線
+  // 区間の横方向オフセット(R区間はL区間の鏡像ではなく平行移動コピー)
+  SECTION_OFFSET_X: { L: 0, R: SECTION_OFFSET_R_X },
+  // 車線の中心X。index 0 = 追い越し(進行方向の右端), 2 = 走行車線(左端), 3 = 加速車線(左外側)
+  LANE_X: { L: LANE_X_L, R: LANE_X_L.map((x) => x + SECTION_OFFSET_R_X) },
   LANE_CHANGE_DURATION: 1.4, // 車線変更所要時間 (s)
   LANE_CHANGE_WAIT_MAX_DURATION: 2.6, // 変更待機の上限 (s)
   LANE_CHANGE_RETRY_COOLDOWN: 2.2, // キャンセル後の再試行クールダウン (s)

--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -89,7 +89,7 @@ export class Vehicle {
   ) {
     this.world = world;
     this.section = section; // 'L' = 義務あり / 'R' = 義務なし
-    this.lane = lane; // 0 = 追い越し車線
+    this.lane = lane; // 0 = 追い越し車線(進行方向の右端)
     this.z = z;
     this.typeName = typeName;
     this.type = TYPES[typeName];

--- a/src/render/night.ts
+++ b/src/render/night.ts
@@ -104,11 +104,14 @@ nightDome.material.opacity = 0;
   nightGroup.add(halo);
 })();
 
-// 街灯(各区間の右路肩から車道側へアームを伸ばすシングルアーム式・ナトリウム灯)
+// 街灯(2区間の中央から両側へアームを伸ばすダブルアーム式・ナトリウム灯)。
+// #28 で2本の道路は同じ向きの平行配置になったため、その中心線(左右対称の軸)に
+// 沿って1列だけ立て、両区間の内側を左右対称に照らす
+const MEDIAN_X = (sectionX('L', -7) + sectionX('R', -7)) / 2; // 2区間の中心線
 (function buildStreetLamps() {
   const poleMaterial = new THREE.MeshLambertMaterial({ color: 0x6f7780 });
   const poleGeometry = new THREE.BoxGeometry(0.2, 7.2, 0.2);
-  const armGeometry = new THREE.BoxGeometry(2.7, 0.16, 0.16);
+  const armGeometry = new THREE.BoxGeometry(5.4, 0.16, 0.16);
   const headGeometry = new THREE.BoxGeometry(0.9, 0.22, 0.42);
   const glowGeometry = new THREE.PlaneGeometry(13, 13);
   const polePositions: [number, number, number][] = [];
@@ -117,17 +120,17 @@ nightDome.material.opacity = 0;
   const glowMatrices: THREE.Matrix4[] = [];
   const glowRotation = new THREE.Matrix4().makeRotationX(-Math.PI / 2);
   for (let z = -ROAD_HALF + 14; z < ROAD_HALF; z += 42) {
-    for (const section of SECTIONS) {
-      polePositions.push([sectionX(section, 0), 3.6, z]);
-      armPositions.push([sectionX(section, -1.35), 7.1, z]);
-      headPositions.push([sectionX(section, -2.6), 7.0, z]);
+    polePositions.push([MEDIAN_X, 3.6, z]);
+    armPositions.push([MEDIAN_X, 7.1, z]);
+    for (const side of [-1, 1]) {
+      headPositions.push([MEDIAN_X + side * 2.6, 7.0, z]);
       // 電球のにじみ(夜のみ): 灯具が光源として「光って見える」ように
       const bulb = new THREE.Sprite(bulbMaterial);
       bulb.scale.set(2.6, 2.6, 1);
-      bulb.position.set(sectionX(section, -2.6), 6.92, z);
+      bulb.position.set(MEDIAN_X + side * 2.6, 6.92, z);
       nightGroup.add(bulb);
       // 路面の光だまり(夜のみ)
-      glowMatrices.push(glowRotation.clone().setPosition(sectionX(section, -3.2), 0.03, z));
+      glowMatrices.push(glowRotation.clone().setPosition(MEDIAN_X + side * 3.2, 0.03, z));
     }
   }
   scene.add(instancedAt(poleGeometry, poleMaterial, polePositions));

--- a/src/render/night.ts
+++ b/src/render/night.ts
@@ -11,7 +11,7 @@ import {
   bulbMaterial,
   signGlowMaterial,
 } from './materials';
-import { GANTRY_Z } from './track';
+import { GANTRY_Z, SECTIONS, sectionX } from './track';
 import { instancedAt, instancedWith } from './instancing';
 
 const ROAD_HALF = CONST.ROAD_HALF;
@@ -104,11 +104,11 @@ nightDome.material.opacity = 0;
   nightGroup.add(halo);
 })();
 
-// 街灯(中央分離帯から両側へアームを伸ばすダブルアーム式・ナトリウム灯)
+// 街灯(各区間の右路肩から車道側へアームを伸ばすシングルアーム式・ナトリウム灯)
 (function buildStreetLamps() {
   const poleMaterial = new THREE.MeshLambertMaterial({ color: 0x6f7780 });
   const poleGeometry = new THREE.BoxGeometry(0.2, 7.2, 0.2);
-  const armGeometry = new THREE.BoxGeometry(5.4, 0.16, 0.16);
+  const armGeometry = new THREE.BoxGeometry(2.7, 0.16, 0.16);
   const headGeometry = new THREE.BoxGeometry(0.9, 0.22, 0.42);
   const glowGeometry = new THREE.PlaneGeometry(13, 13);
   const polePositions: [number, number, number][] = [];
@@ -117,17 +117,17 @@ nightDome.material.opacity = 0;
   const glowMatrices: THREE.Matrix4[] = [];
   const glowRotation = new THREE.Matrix4().makeRotationX(-Math.PI / 2);
   for (let z = -ROAD_HALF + 14; z < ROAD_HALF; z += 42) {
-    polePositions.push([0, 3.6, z]);
-    armPositions.push([0, 7.1, z]);
-    for (const side of [-1, 1]) {
-      headPositions.push([side * 2.6, 7.0, z]);
+    for (const section of SECTIONS) {
+      polePositions.push([sectionX(section, 0), 3.6, z]);
+      armPositions.push([sectionX(section, -1.35), 7.1, z]);
+      headPositions.push([sectionX(section, -2.6), 7.0, z]);
       // 電球のにじみ(夜のみ): 灯具が光源として「光って見える」ように
       const bulb = new THREE.Sprite(bulbMaterial);
       bulb.scale.set(2.6, 2.6, 1);
-      bulb.position.set(side * 2.6, 6.92, z);
+      bulb.position.set(sectionX(section, -2.6), 6.92, z);
       nightGroup.add(bulb);
       // 路面の光だまり(夜のみ)
-      glowMatrices.push(glowRotation.clone().setPosition(side * 3.2, 0.03, z));
+      glowMatrices.push(glowRotation.clone().setPosition(sectionX(section, -3.2), 0.03, z));
     }
   }
   scene.add(instancedAt(poleGeometry, poleMaterial, polePositions));
@@ -140,7 +140,7 @@ nightDome.material.opacity = 0;
 {
   const signGlowPositions: [number, number, number][] = [];
   for (const z of GANTRY_Z)
-    for (const centerX of [-7, 7]) signGlowPositions.push([centerX, 8.3, z]);
+    for (const section of SECTIONS) signGlowPositions.push([sectionX(section, -7), 8.3, z]);
   nightGroup.add(
     instancedAt(new THREE.PlaneGeometry(13.5, 5.6), signGlowMaterial, signGlowPositions),
   );

--- a/src/render/track.ts
+++ b/src/render/track.ts
@@ -34,24 +34,30 @@ export const SECTION_THEME: Record<Section, SectionTheme> = {
   },
 };
 
+/* ---- 区間の座標系 ----
+   道路の形は左右で同一。R区間は鏡像ではなくL区間の平行移動コピーなので、
+   位置はすべて「L区間の座標系」で書き、区間ごとのオフセットを足して実座標にする。
+   これで両区間とも 追い越し車線 = 右端 / 加速車線 = 左外側 に揃う (Issue #28) */
+export const SECTIONS = ['L', 'R'] as const;
+export function sectionX(section: Section, xInSectionFrame: number): number {
+  return xInSectionFrame + CONST.SECTION_OFFSET_X[section];
+}
+
 /* ---- 道路(アスファルト質感 + 区間ごとの色味) ---- */
-for (const [section, centerX] of [
-  ['L', -7],
-  ['R', 7],
-] as [Section, number][]) {
+for (const section of SECTIONS) {
   const road = new THREE.Mesh(
     new THREE.BoxGeometry(13.2, 0.12, ROAD_HALF * 2),
     new THREE.MeshLambertMaterial({ color: SECTION_THEME[section].road, map: asphaltTexture }),
   );
-  road.position.set(centerX, -0.06, 0);
+  road.position.set(sectionX(section, -7), -0.06, 0);
   road.receiveShadow = true;
   scene.add(road);
-  // 外側の路肩ライン(テーマカラー)
+  // 進行方向左側(加速車線側)の路肩ライン(テーマカラー)
   const strip = new THREE.Mesh(
     new THREE.BoxGeometry(0.7, 0.06, ROAD_HALF * 2),
     new THREE.MeshBasicMaterial({ color: SECTION_THEME[section].strip }),
   );
-  strip.position.set(centerX < 0 ? -14.1 : 14.1, -0.03, 0);
+  strip.position.set(sectionX(section, -14.1), -0.03, 0);
   scene.add(strip);
 }
 
@@ -70,14 +76,11 @@ function dashedLines(xPositions: number[]): void {
     for (let z = -ROAD_HALF + 2; z < ROAD_HALF; z += 12) positions.push([x, 0.01, z]);
   scene.add(instancedAt(geometry, whiteLineMaterial, positions));
 }
-[-1, -13, 1, 13].forEach(solidLine);
-dashedLines([-5, -9, 5, 9]);
+for (const section of SECTIONS) for (const x of [-1, -13]) solidLine(sectionX(section, x));
+dashedLines(SECTIONS.flatMap((section) => [-5, -9].map((x) => sectionX(section, x))));
 
 /* ---- 合流ランプ(加速車線) ---- */
-for (const [section, side] of [
-  ['L', -1],
-  ['R', 1],
-] as [Section, number][]) {
+for (const section of SECTIONS) {
   const zTop = CONST.RAMP_Z_TOP + 14,
     zEnd = CONST.RAMP_Z_END - 16;
   const length = zTop - zEnd,
@@ -86,16 +89,17 @@ for (const [section, side] of [
     new THREE.BoxGeometry(3.6, 0.12, length),
     new THREE.MeshLambertMaterial({ color: SECTION_THEME[section].road, map: asphaltTexture }),
   );
-  ramp.position.set(15 * side, -0.055, zCenter);
+  ramp.position.set(sectionX(section, -15), -0.055, zCenter);
   ramp.receiveShadow = true;
   scene.add(ramp);
   const edge = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.02, length), whiteLineMaterial);
-  edge.position.set(16.7 * side, 0.012, zCenter);
+  edge.position.set(sectionX(section, -16.7), 0.012, zCenter);
   scene.add(edge);
   // 本線との境界は破線(合流可)
   const dashGeometry = new THREE.BoxGeometry(0.15, 0.02, 3);
   const dashPositions: [number, number, number][] = [];
-  for (let z = zEnd + 12; z < zTop - 6; z += 9) dashPositions.push([13 * side, 0.012, z]);
+  for (let z = zEnd + 12; z < zTop - 6; z += 9)
+    dashPositions.push([sectionX(section, -13), 0.012, z]);
   scene.add(instancedAt(dashGeometry, whiteLineMaterial, dashPositions));
   // 終端の導流帯(先細りのゼブラ)。単位ボックスをX方向スケールで先細りに
   const zebraGeometry = new THREE.BoxGeometry(1, 0.02, 1.3);
@@ -105,16 +109,18 @@ for (const [section, side] of [
     zebraMatrices.push(
       new THREE.Matrix4()
         .makeScale(width, 1, 1)
-        .setPosition((13.1 + width / 2) * side, 0.012, zEnd + 9 - i * 3.2),
+        .setPosition(sectionX(section, -13.1 - width / 2), 0.012, zEnd + 9 - i * 3.2),
     );
   }
   scene.add(instancedWith(zebraGeometry, whiteLineMaterial, zebraMatrices));
 }
 
-/* ---- 中央分離帯（ガードレール付き） ---- */
-(function buildMedian() {
+/* ---- 区間の仕切り（ガードレール付き） ----
+   両区間は同じ向きに走る独立した道路なので「中央分離帯」ではなく、
+   L区間の右路肩と R区間の加速車線の間に立つ仕切りの防護柵 */
+(function buildDivider() {
   const base = new THREE.Mesh(
-    new THREE.BoxGeometry(1.5, 0.5, ROAD_HALF * 2),
+    new THREE.BoxGeometry(0.8, 0.5, ROAD_HALF * 2),
     new THREE.MeshLambertMaterial({ color: 0x9aa0a6 }),
   );
   base.position.set(0, 0.25, 0);
@@ -122,7 +128,7 @@ for (const [section, side] of [
   base.receiveShadow = true;
   scene.add(base);
   const railMaterial = new THREE.MeshLambertMaterial({ color: 0xe9edf0 });
-  for (const railX of [-0.6, 0.6]) {
+  for (const railX of [-0.3, 0.3]) {
     const rail = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.14, ROAD_HALF * 2), railMaterial);
     rail.position.set(railX, 0.95, 0);
     scene.add(rail);
@@ -197,10 +203,10 @@ function roadText(text: string, x: number, z: number): void {
   mesh.position.set(x, 0.015, z);
   scene.add(mesh);
 }
-roadText('義務あり', -7, -120);
-roadText('義務なし', 7, -120);
-roadText('ゆずりあい', -7, 60);
-roadText('マイペース', 7, 60);
+roadText('義務あり', sectionX('L', -7), -120);
+roadText('義務なし', sectionX('R', -7), -120);
+roadText('ゆずりあい', sectionX('L', -7), 60);
+roadText('マイペース', sectionX('R', -7), 60);
 
 /* ---- 頭上標識ゲート(カメラをどう回しても区間が分かるように両面・両端に設置) ---- */
 export const GANTRY_Z = [-300, -100, 100, 300];
@@ -224,7 +230,7 @@ function makeSignTexture(title: string, subtitle: string, background: string): T
 }
 function buildGantry(section: Section, z: number): void {
   const theme = SECTION_THEME[section];
-  const centerX = section === 'L' ? -7 : 7;
+  const centerX = sectionX(section, -7);
   const group = new THREE.Group();
   const steel = new THREE.MeshLambertMaterial({ color: 0x99a1aa });
   for (const postX of [centerX - 6.9, centerX + 6.9]) {
@@ -249,6 +255,6 @@ function buildGantry(section: Section, z: number): void {
   }
   scene.add(group);
 }
-for (const section of ['L', 'R'] as const) {
+for (const section of SECTIONS) {
   for (const gantryZ of GANTRY_Z) buildGantry(section, gantryZ);
 }

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -520,3 +520,66 @@ describe('スムーズだった時間の累積 (Issue #26)', () => {
     expect(world.smoothTime, 'リセット後も累積が残っている').toEqual({ L: 0, R: 0, draw: 0 });
   });
 });
+
+/* ============================================================
+   10. 車線配置 (Issue #28)
+   両区間とも進行方向は -Z(前方 = z が小さい側)なので、進行方向を向いた
+   時の「右」は +X 側。追い越し車線(index 0)が両区間とも右端に来ること、
+   R区間がL区間の鏡像ではなく平行移動コピー(= 合流条件が完全に同一)で
+   あることを検証する。
+   ============================================================ */
+describe('車線配置（追い越し車線は右側）', () => {
+  const SECTIONS = ['L', 'R'] as const;
+
+  test('前方は z が小さい側（進行方向 -Z）', () => {
+    const world = new World({ rng: createRng(28), spawnInterval: 1e9 });
+    const vehicle = new Vehicle(world, 'L', 1, 0, 'Sedan', 25);
+    world.vehicles.push(vehicle);
+    world.rebuildSectionIndex();
+    for (let i = 0; i < 20; i++) world.step(TIME_STEP);
+    expect(vehicle.z, '車両は -Z 方向へ進む').toBeLessThan(0);
+  });
+
+  test.each(SECTIONS)('%s区間: 追い越し車線が右端・加速車線が左外側', (section) => {
+    const laneXs = CONST.LANE_X[section];
+    // 右 = +X。index が増えるほど左へ並ぶ(0 = 追い越し, 2 = 走行, 3 = 加速車線)
+    for (let lane = 1; lane < laneXs.length; lane++) {
+      expect(
+        laneXs[lane],
+        `${section}区間: 車線${lane} が 車線${lane - 1} より右にある`,
+      ).toBeLessThan(laneXs[lane - 1]);
+    }
+  });
+
+  test('R区間はL区間の鏡像ではなく平行移動コピー（合流条件が同一）', () => {
+    const offset = CONST.SECTION_OFFSET_X.R - CONST.SECTION_OFFSET_X.L;
+    expect(offset, '平行移動量が 0 だと2区間が重なる').toBeGreaterThan(0);
+    for (let lane = 0; lane < CONST.LANE_X.L.length; lane++) {
+      expect(
+        CONST.LANE_X.R[lane] - CONST.LANE_X.L[lane],
+        `車線${lane} の左右オフセットが一定でない`,
+      ).toBeCloseTo(offset, 10);
+    }
+  });
+
+  test.each(SECTIONS)('%s区間: 加速車線は合流先の走行車線(2)の左隣', (section) => {
+    const laneXs = CONST.LANE_X[section];
+    expect(laneXs[3], '加速車線が走行車線より左にない').toBeLessThan(laneXs[2]);
+    expect(laneXs[2] - laneXs[3], '加速車線と走行車線の間隔が車線幅と異なる').toBeCloseTo(
+      laneXs[1] - laneXs[2],
+      10,
+    );
+  });
+
+  test('生成された車両のXは車線位置に一致する', () => {
+    const world = new World({ rng: createRng(29), spawnInterval: 1e9 });
+    for (const section of SECTIONS) {
+      for (let lane = 0; lane < 4; lane++) {
+        const vehicle = new Vehicle(world, section, lane, 0, 'Sedan', 25);
+        expect(vehicle.x, `${section}区間 車線${lane} のXが不一致`).toBe(
+          CONST.LANE_X[section][lane],
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #28

## 問題

両区間とも進行方向は `-Z`(前方 = z が小さい側)なので、進行方向を向いた時の「右」は `+X` 側になる。
ところが R区間は L区間の**鏡像**として配置されていたため:

| | 追い越し車線(lane 0) | 加速車線(lane 3) |
|---|---|---|
| L区間 | x=-3 = 右端 ✅ | x=-15 = 左外側 ✅ |
| R区間 | x=+3 = **左端** ❌ | x=+15 = **右外側** ❌ |

R区間だけ日本の道路と左右が逆になっていた。

## 調査結果

`lane` は徹底して index のみで扱われており、座標 `x` に依存するロジックは存在しなかった。

- `vehicle.ts`: 車線変更は `lane - 1`(追い越し方向) / `lane + 1`(走行車線方向)の index 演算のみ。`LANE_X` を読むのは生成時と車線変更の補間だけ
- `world.ts`: `LANE_X` を読むのは入口待ちからの流入時に `x` を置く1箇所だけ
- `keepLeft` / `keepRightTimer` という既存の命名も「index 増 = 左 / lane 0 = 右」を前提にしており、**コードの意味論は元から「追い越し車線 = 右」だった**。破綻していたのは R区間のジオメトリだけ

## 方針

Issue が懸念していた「合流の左右非対称」は、**R区間を鏡像ではなくL区間の平行移動コピー(+17.2)にする**ことで立体交差を作らずに解消できる。
両区間が合同な道路になるため、合流条件は左右対称どころか完全に同一になる。

```
[L加速車線][L走行][L追越] | 仕切り | [R加速車線][R走行][R追越]
 -16.8 ────────── -0.4    0    0.4 ────────────── 16.8
```

- 全体の占有幅は変更前と同じ(x = ±16.8 で左右対称)。カメラ・路側の防護柵・遮音壁・並木は無変更
- 中央分離帯は「同じ向きに走る2本の道路の仕切り」になったため、幅 1.5 → 0.8 に縮めて名称も `buildDivider` に変更
- 街灯は左右の道路の中心が一致しなくなったため、ダブルアーム式(中央分離帯から両側)→ 各区間の右路肩からのシングルアーム式に変更

## 変更

- `src/core/constants.ts`: `SECTION_OFFSET_X` を追加し `LANE_X.R` を L の平行移動で定義。lane index の意味をコメントに明記
- `src/render/track.ts`: 位置をすべて「L区間の座標系 + オフセット」で記述する `sectionX()` に統一(道路・路肩ライン・車線マーキング・合流ランプ・導流帯・路面ペイント・標識ゲート)
- `src/render/night.ts`: 街灯と標識投光を区間オフセット対応に
- `traffic-simulation.test.ts`: 車線配置のテストを追加

## テスト

追加した `車線配置（追い越し車線は右側）`:
- 進行方向が `-Z` であること(= 右が `+X` であることの前提)
- 各区間で lane index が増えるほど左に並ぶこと(0 = 追い越し = 右端, 3 = 加速車線 = 左外側)
- R区間の各車線の x が L区間から一定量の平行移動であること(= 合流条件が同一)
- 加速車線が合流先の走行車線(2)の左隣に、車線幅と同じ間隔で並ぶこと

## 確認

```
$ pnpm check
pass: All 32 files are correctly formatted (513ms, 4 threads)
pass: Found no warnings, lint errors, or type errors in 25 files (544ms, 4 threads)

$ pnpm test
 Test Files  1 passed (1)
      Tests  40 passed (40)

$ pnpm build
✓ built in 361ms
```

ブラウザでの描画も確認済み(コンソールエラーなし)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
