### PR TITLE
fix: 車線変更時の車体ロールを自然な外傾に修正 (#34)

### DIFF
--- a/src/render/vehicle-mesh.ts
+++ b/src/render/vehicle-mesh.ts
@@ -49,7 +49,9 @@ export interface VehicleMesh {
   brakeGlow: THREE.Mesh;
   previousX: number;
   previousSpeed: number;
+  previousLateralVelocity: number;
   pitch: number;
+  roll: number;
   habit: DriverHabit;
 }
 
@@ -518,7 +520,9 @@ function buildVehicleMesh(vehicle: Vehicle): VehicleMesh {
     brakeGlow,
     previousX: vehicle.x + habit.bias,
     previousSpeed: vehicle.speed,
+    previousLateralVelocity: 0,
     pitch: 0,
+    roll: 0,
     habit,
   };
 }
@@ -553,7 +557,17 @@ export function syncMeshes(world: World, deltaTime: number): void {
     mesh.previousX = x;
     // 操舵ヨー + 車体ロール + 加減速のピッチ(ノーズダイブ/スクワット)
     mesh.group.rotation.y = clamp(-lateralVelocity / (vehicle.speed + 6), -0.16, 0.16) * 1.5;
-    mesh.group.rotation.z = mesh.group.rotation.y * 0.3;
+    // 車体ロール: 横加速度による重量移動を再現する。乗用車の緩やかな車線変更では
+    // ほぼ水平を保ち、切り込み・切り戻しの瞬間だけ旋回の「外側」へわずかに傾く。
+    // (操舵ヨーへ単純比例させると、ハンドルを切っただけで内側へ深く傾き、
+    //  バイクのバンクのように見えて不自然。横加速度基準にすると傾く向きが正しくなり、
+    //  車線変更の前半で外へ、後半で戻る自然な揺り戻しになる)
+    const lateralAcceleration =
+      deltaTime > 0 ? (lateralVelocity - mesh.previousLateralVelocity) / deltaTime : 0;
+    mesh.previousLateralVelocity = lateralVelocity;
+    const rollTarget = clamp(lateralAcceleration * 0.0025, -0.03, 0.03);
+    mesh.roll += (rollTarget - mesh.roll) * Math.min(1, deltaTime * 6); // 急な横G変化を均して滑らかに
+    mesh.group.rotation.z = mesh.roll;
     const acceleration = deltaTime > 0 ? (vehicle.speed - mesh.previousSpeed) / deltaTime : 0;
     mesh.previousSpeed = vehicle.speed;
     mesh.pitch +=


### PR DESCRIPTION
## 概要
Issue #34「車線変更時の傾きが不自然」への対応。

車体ロール(`rotation.z`)を操舵ヨーへ単純比例させていたため、ハンドルを切る(=車線変更で横移動する)だけで車体が旋回の**内側**へ深く傾き、バイクのバンクのような不自然な挙動になっていた(乗用車として不自然)。

## 変更内容
`src/render/vehicle-mesh.ts` の毎フレーム更新で、ロールの根拠を **横加速度**(`lateralVelocity` の変化)へ変更した。

- 変更前: `rotation.z = rotation.y * 0.3`(操舵ヨーに単純比例・内傾・最大約4°)
- 変更後: 横加速度に比例した**外傾**へ符号反転し、係数・クランプも大幅縮小。平滑化して滑らかにする。
  ```ts
  const lateralAcceleration = (lateralVelocity - previousLateralVelocity) / deltaTime;
  const rollTarget = clamp(lateralAcceleration * 0.0025, -0.03, 0.03);
  roll += (rollTarget - roll) * min(1, deltaTime * 6);
  rotation.z = roll;
  ```

コア(`LANE_X` 間隔4 / `LANE_CHANGE_DURATION` 1.4s / smoothstep)から算出した典型的な車線変更でのロール量を数値検証:

| 進行 | 横加速度(m/s²) | ロール |
|---|---|---|
| 0.1 (切り込み) | +10.2 | +0.86° (外側) |
| 0.5 (中間) | +0.3 | +0.39° |
| 1.0 (切り戻し) | -12.0 | -1.34° (逆へ揺り戻し) |

最大でも約1.3°に収まり、車線変更の前半で外へ傾き後半で戻る自然な揺り戻しになる。ヨー・ピッチ・無意識の蛇行(sway)は変更していない。

## 検証
- `pnpm check` パス(format / lint / typecheck)
- `pnpm test` パス(38 tests)
- `pnpm build` 成功
- 挙動の数値シミュレーションで符号(外傾)・振幅(控えめ)・平滑性を確認
- ヘッドレスブラウザは本環境のChrome/Playwrightバージョン不整合で起動不可のため目視描画は未実施

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)