### PR TITLE
MIT ライセンスを追加し README に依存ライセンスの但し書きを記載

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 bmthd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -74,3 +74,14 @@ src/
 **ルール**: `src/core/` は DOM / THREE に依存させない。
 テスト (`traffic-simulation.test.ts`) は Vitest がコアを直接 import して実行する。
 シミュレーションの挙動を変えるときは core、見た目は render / ui だけを触ればよい。
+
+## ライセンス
+
+本リポジトリのコードは [MIT License](./LICENSE) で提供する。
+
+ただし、サードパーティの依存およびアセットはそれぞれ独自のライセンスに従う。
+再配布や再利用の際は個別に確認すること。
+
+- [three.js](https://github.com/mrdoob/three.js): MIT License
+- [lucide](https://github.com/lucide-icons/lucide): ISC License
+  (Feather 由来の部分は MIT License)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "6車線比較 渋滞シミュレーション",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vp dev",


### PR DESCRIPTION
## 変更内容

public リポジトリでありながらライセンスファイルが無く、第三者がフォーク・再利用・コントリビュートを法的に行えない状態だったため、MIT License を明示した。

- `LICENSE` を新規追加（MIT License, Copyright (c) 2026 bmthd）
- `package.json` に `"license": "MIT"` を追加
- `README.md` に「ライセンス」節を追加し、本リポジトリのコードが MIT であること、およびサードパーティの依存・アセットは個別のライセンスに従うことを明記
  - three.js: MIT License
  - lucide: ISC License（Feather 由来の部分は MIT License）

コードの変更は無く、ドキュメントとメタデータのみの変更。

## 検証結果

`.claude/worktrees/agent-a368a7a8ed8a0421c` にて実行。

- `pnpm test`

```
 Test Files  1 passed (1)
      Tests  49 passed (49)
```

- `pnpm exec tsc --noEmit`

```
TypeScript: No errors found
```

いずれも `origin/main` のベースラインと同一（テスト 1 ファイル / 49 件、型エラー 0）。

Closes #59
