### PR TITLE
復帰フォールバックの区間依存分岐を除去し reset() の内部状態初期化を修正

### DIFF
--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -579,7 +579,7 @@ export class Vehicle {
           // 復帰先が塞がっている: まず「加速して並走車の前に出て戻る」を試み、
           // 見込みがなければ従来どおり少し減速して並走車の後ろに入る
           if (this.returnBoostCooldown > 0 || !this.tryStartReturnBoost(ahead)) {
-            if (this.section === 'L' && this.hasDeadlockAlongside(1)) this.yieldSlowTimer = 1.0;
+            if (this.hasDeadlockAlongside(1)) this.yieldSlowTimer = 1.0;
           }
         }
       }

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -313,8 +313,20 @@ export class World {
     this.vehicles.length = 0;
     this.spawnAccumulator = 0;
     this.time = 0;
+    this.sectionVehicles = { L: [], R: [] };
+    this.stats = {
+      changes: { L: 0, R: 0 },
+      yields: { L: 0, R: 0 },
+      cancels: { L: 0, R: 0 },
+      inflow: { L: 0, R: 0 },
+      outflow: { L: 0, R: 0 },
+    };
     this.smoothTime = { L: 0, R: 0, draw: 0 }; // 累積の比較もやり直す
+    this.absorberRoundRobin = null;
+    this.laneRoundRobin = 0;
+    this.perturbTimer = null;
     this.populateInitial();
+    this.rebuildSectionIndex();
   }
 
   rebuildSectionIndex(): void {

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -676,3 +676,107 @@ describe('合流(加速車線)の協調 (Issue #33)', () => {
     expect(main.yieldSlowTimer, '速度差が大きいのに譲ってしまった').toBe(0);
   });
 });
+
+/* ============================================================
+   10. 追い越し車線からの復帰は区間非依存 (Issue #49)
+   復帰先が並走車に塞がれ、加速復帰にも見込みがない時のフォールバック
+   (少し減速して並走車の後ろに入る)は「追いつかれた車両の義務」とは
+   無関係な一般的な運転挙動なので、L/R 両区間でまったく同じ条件で
+   発動しなければならない(AGENTS.md A項: 区間依存変数を挙動分岐に使わない)。
+   ============================================================ */
+describe('復帰フォールバックの区間非依存性 (Issue #49)', () => {
+  // 追い越し車線(lane 0)の車が後続に追いつかれ、復帰先(lane 1)は同速の並走車に
+  // 塞がれ、さらに並走車の前方も塞がっているため加速復帰の見込みもない状況。
+  // このとき「少し減速して並走車の後ろに入る」(yieldSlowTimer) が発動する。
+  function setupBlockedReturn(section: 'L' | 'R') {
+    const world = new World({ rng: createRng(9), spawnInterval: 1e9 });
+    const overtaker = new Vehicle(world, section, 0, 0, 'Sedan', 25);
+    overtaker.speed = 25;
+    // 復帰判定時間は気質(義務の有無)由来なので、発動条件の比較のため揃える
+    overtaker.returnTime = CONST.OVERTAKE_LANE_RETURN_TIME;
+    overtaker.returnTimer = overtaker.returnTime + TIME_STEP;
+    overtaker.returnBoostCooldown = 1;
+    overtaker.keepLeft = false;
+    overtaker.camper = false;
+    const side = new Vehicle(world, section, 1, 0, 'Sedan', 25); // 同速の並走車
+    side.speed = 25;
+    side.keepLeft = false;
+    side.camper = false;
+    const wall = new Vehicle(world, section, 1, -22, 'Sedan', 24.5); // 並走車の前方を塞ぐ
+    wall.speed = 24.5;
+    wall.keepLeft = false;
+    wall.camper = false;
+    const chaser = new Vehicle(world, section, 0, 55, 'SportsCar', 34);
+    chaser.speed = 32;
+    world.vehicles.push(overtaker, side, wall, chaser);
+    world.rebuildSectionIndex();
+    return { world, overtaker };
+  }
+
+  function runUntilSlowed(section: 'L' | 'R'): boolean {
+    const { overtaker } = setupBlockedReturn(section);
+    overtaker.decide(null, TIME_STEP);
+    return overtaker.lane === 0 && overtaker.yieldSlowTimer > 0;
+  }
+
+  test.each([
+    ['義務あり', 'L'],
+    ['義務なし', 'R'],
+  ] as const)(
+    '%s区間: 復帰先が塞がれ加速復帰も見込めない時は減速して後ろに入る',
+    (_name, section) => {
+      expect(runUntilSlowed(section), '減速フォールバック(yieldSlowTimer)が発動しなかった').toBe(
+        true,
+      );
+    },
+  );
+
+  test('L/R で発動可否が一致する(区間依存の分岐が残っていない)', () => {
+    expect(runUntilSlowed('R'), 'R区間だけ発動しない = section 依存の分岐が残っている').toBe(
+      runUntilSlowed('L'),
+    );
+  });
+});
+
+/* ============================================================
+   11. リセット時の内部状態初期化 (Issue #54)
+   コンストラクタで初期化される集計・索引・モード用タイマーは、リセット後に
+   前回実行の状態を持ち越してはならない。
+   ============================================================ */
+describe('リセット時の内部状態初期化 (Issue #54)', () => {
+  test('reset() は累積値と古い車両索引を初期状態へ戻す', () => {
+    const world = new World({ rng: createRng(54), spawnInterval: 1e9 });
+    world.populateInitial();
+    world.step(TIME_STEP);
+    const staleVehicle = world.vehicles[0];
+
+    world.stats.changes.L = 7;
+    world.stats.yields.R = 8;
+    world.stats.cancels.L = 9;
+    world.stats.inflow.R = 10;
+    world.stats.outflow.L = 11;
+    world.sectionVehicles.L = [staleVehicle];
+    world.sectionVehicles.R = [staleVehicle];
+    world.laneRoundRobin = 2;
+    world.perturbTimer = 3;
+    world.absorberRoundRobin = [1, 2, 3];
+
+    world.reset();
+
+    expect(world.spawnAccumulator).toBe(0);
+    expect(world.time).toBe(0);
+    expect(world.stats).toEqual({
+      changes: { L: 0, R: 0 },
+      yields: { L: 0, R: 0 },
+      cancels: { L: 0, R: 0 },
+      inflow: { L: 0, R: 0 },
+      outflow: { L: 0, R: 0 },
+    });
+    expect(world.smoothTime).toEqual({ L: 0, R: 0, draw: 0 });
+    expect(world.sectionVehicles.L).not.toContain(staleVehicle);
+    expect(world.sectionVehicles.R).not.toContain(staleVehicle);
+    expect(world.laneRoundRobin).toBe(0);
+    expect(world.perturbTimer).toBeNull();
+    expect(world.absorberRoundRobin).toBeNull();
+  });
+});


### PR DESCRIPTION
## 変更内容

### 1. 追い越し車線からの復帰フォールバックを区間非依存化 (Issue #49)

`src/core/vehicle.ts` の復帰処理に残っていた区間依存の分岐を削除した。

```diff
-            if (this.section === 'L' && this.hasDeadlockAlongside(1)) this.yieldSlowTimer = 1.0;
+            if (this.hasDeadlockAlongside(1)) this.yieldSlowTimer = 1.0;
```

短絡評価のため R 区間では `hasDeadlockAlongside(1)` が呼ばれることすらなく、「復帰先が塞がれた時に少し減速して後ろに入る」挙動が L 区間にしか存在しなかった。直前のコメント（「両区間共通だが、復帰の早さは気質 (returnTime) で異なる」）および `tryStartReturnBoost` の説明とも実装が矛盾していた。

### 2. `reset()` が内部状態をクリアしていなかった問題を修正 (Issue #54)

`src/core/world.ts` の `reset()` で、これまで `smoothTime` しかクリアしていなかったものを次のように拡張した。

- `stats`（`changes` / `yields` / `cancels` / `inflow` / `outflow`）をゼロクリア
- `sectionVehicles` を空にし、`populateInitial()` 後に `rebuildSectionIndex()` を呼んで再構築（破棄済み車両への参照が次の `step()` まで残るのを防ぐ）
- `absorberRoundRobin` / `laneRoundRobin` / `perturbTimer` を初期値に戻す

`reset()` はリセットボタンとパラメータ変更時の両方から呼ばれるため、UI 操作のたびに古い統計が残っていた。

### 3. テスト追加

`traffic-simulation.test.ts` の末尾に既存セクションと重複しない `describe` を 2 つ追加した。

- `復帰フォールバックの区間非依存性 (Issue #49)`
- `リセット時の内部状態初期化 (Issue #54)`

## AGENTS.md A 項（実験的妥当性の不変条件）との関係

AGENTS.md A 項は「**L/R の挙動差は『追いつかれた車両の義務』ただ 1 つでなければならない**」と定めており、区間で値が変わる変数（`section` / `yields` など）を挙動分岐に使うことを禁じている。許可されている例外は `if (this.yields && flowing && this.lane < 2)`（追いつかれた車両の義務）とキープレフトの 2 箇所のみである。

本 PR は `this.section === 'L' &&` を**削除**する変更であり、**区間依存条件をむしろ 1 つ減らしている**。A 項が特に強く戒める「スコア差の数値を回復するために区間依存の条件を足して辻褄を合わせる」行為とは逆向きの変更であり、不変条件に近づく方向の是正である。

また、L/R 渋滞スコア差の回帰ガード（`DIFF_TARGET = 10`、10 シード平均で 約 10 ± 2）を含む既存テストは**期待値を一切緩めずにそのまま通っている**。つまり区間非依存化によってスコア差は許容範囲内に収まっており、辻褄合わせの追加条件は不要だった。

## 検証結果

`.claude/worktrees/agent-ad5a6eeef1a8d6c9e` にて実行。

- `pnpm test`

```
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

`origin/main` のベースラインは 49 件。本 PR で追加した 4 件を加えた 53 件がすべて pass しており、既存 49 件（L/R スコア差の回帰ガードを含む）に失敗は無い。

- `pnpm exec tsc --noEmit`

```
TypeScript: No errors found
```

Closes #49
Closes #54
