### PR TITLE
カメラが車体に干渉した際に車体シェルを非表示にする

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,7 @@ import { scene, camera, renderer } from './render/scene';
 import './render/track';
 import './render/scenery';
 import { applyEnv, tickTheme } from './render/theme';
-import { syncMeshes } from './render/vehicle-mesh';
+import { syncMeshes, updateVehicleCameraOcclusion } from './render/vehicle-mesh';
 import { updateCamera, setupCameraControls } from './render/camera';
 import { icon, renderIcons } from './ui/icons';
 import { showMessage } from './ui/notify';
@@ -61,6 +61,7 @@ export function start(): void {
       updateHUD(world);
     }
     updateCamera(world, deltaTime);
+    updateVehicleCameraOcclusion(world);
     renderer.render(scene, camera);
   }
 

--- a/src/render/vehicle-mesh.ts
+++ b/src/render/vehicle-mesh.ts
@@ -7,7 +7,7 @@ import * as THREE from 'three';
 import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils';
 import { CONST, TYPES, clamp } from '../core';
 import type { Vehicle, VehicleTypeName, World } from '../core';
-import { scene } from './scene';
+import { camera, scene } from './scene';
 import {
   paint,
   glassMaterial,
@@ -41,6 +41,7 @@ interface DriverHabit {
 
 export interface VehicleMesh {
   group: THREE.Group;
+  shellParts: THREE.Mesh[];
   brakeMaterial: THREE.MeshBasicMaterial;
   blinkLeft: THREE.MeshBasicMaterial;
   blinkRight: THREE.MeshBasicMaterial;
@@ -108,6 +109,7 @@ interface Blueprint {
 }
 
 const blueprintCache: Partial<Record<VehicleTypeName, Blueprint>> = {};
+const cameraLocalPosition = new THREE.Vector3();
 
 function buildBlueprint(typeName: VehicleTypeName): Blueprint {
   const spec = TYPES[typeName],
@@ -447,30 +449,38 @@ function buildVehicleMesh(vehicle: Vehicle): VehicleMesh {
   const vehicleBlueprint = blueprint(vehicle.typeName);
   const bodyLength = vehicle.type.length;
   const group = new THREE.Group();
+  const shellParts: THREE.Mesh[] = [];
   // 各パーツはブループリント側で位置決め済み(ローカル変換は恒等)なので、
   // 毎フレームの行列再計算を止めて描画コストを下げる
-  function addPart(slot: PartSlot, material: THREE.Material, castShadow?: boolean): void {
+  function addPart(
+    slot: PartSlot,
+    material: THREE.Material,
+    castShadow?: boolean,
+  ): THREE.Mesh | null {
     const geometry = vehicleBlueprint.parts[slot];
-    if (!geometry) return;
+    if (!geometry) return null;
     const mesh = new THREE.Mesh(geometry, material);
     if (castShadow) mesh.castShadow = true;
     mesh.matrixAutoUpdate = false;
     group.add(mesh);
+    return mesh;
   }
-  addPart('body', paint(vehicle.color), true);
-  addPart('glass', glassMaterial, true);
-  addPart('trim', trimMaterial);
+  const body = addPart('body', paint(vehicle.color), true);
+  const glass = addPart('glass', glassMaterial, true);
+  const trim = addPart('trim', trimMaterial);
   addPart('tire', tireMaterial, true);
   addPart('hub', hubMaterial);
-  addPart('cargo', cargoMaterial, true);
+  const cargo = addPart('cargo', cargoMaterial, true);
   addPart('plate', plateMaterial);
   addPart('head', headlightMaterial);
+  for (const part of [body, glass, trim, cargo]) if (part) shellParts.push(part);
   if (vehicle.isTaxi) {
     const sign = new THREE.Mesh(taxiSignGeometry, taxiSignMaterial);
     sign.position.set(0, vehicle.type.height * 0.97 + 0.14, (bodyLength / 2) * 0.15);
     sign.matrixAutoUpdate = false;
     sign.updateMatrix();
     group.add(sign);
+    shellParts.push(sign);
   }
   // 灯火類は照明の影響を受けない発光体として描く(昼でもはっきり光って見える)。
   // 色を車両ごとに切り替えるため、マテリアルだけ個別に持つ
@@ -512,6 +522,7 @@ function buildVehicleMesh(vehicle: Vehicle): VehicleMesh {
   };
   return {
     group,
+    shellParts,
     brakeMaterial,
     blinkLeft,
     blinkRight,
@@ -525,6 +536,20 @@ function buildVehicleMesh(vehicle: Vehicle): VehicleMesh {
     roll: 0,
     habit,
   };
+}
+
+function updateShellVisibility(mesh: VehicleMesh, vehicle: Vehicle): void {
+  mesh.group.updateMatrixWorld(true);
+  cameraLocalPosition.copy(camera.position);
+  mesh.group.worldToLocal(cameraLocalPosition);
+  const halfWidth = vehicle.type.width / 2 + 0.45;
+  const halfLength = vehicle.type.length / 2 + 0.9;
+  const insideUpperBody =
+    Math.abs(cameraLocalPosition.x) < halfWidth &&
+    Math.abs(cameraLocalPosition.z) < halfLength &&
+    cameraLocalPosition.y > 0.55 &&
+    cameraLocalPosition.y < vehicle.type.height + 0.9;
+  for (const part of mesh.shellParts) part.visible = !insideUpperBody;
 }
 
 /* ---- ワールドとメッシュの同期 ---- */
@@ -608,5 +633,19 @@ export function syncMeshes(world: World, deltaTime: number): void {
         meshMap.delete(vehicle);
       }
     }
+  }
+}
+
+export function updateVehicleCameraOcclusion(world: World): void {
+  for (const vehicle of world.vehicles) {
+    const mesh = meshMap.get(vehicle);
+    if (!mesh) continue;
+    if (vehicle.waiting) {
+      for (const part of mesh.shellParts) part.visible = true;
+      continue;
+    }
+    // カメラが車体にめり込んだ時だけ、車体上部のシェルを消して視界を確保する。
+    // 個体ごとの描画グループなので、交通挙動や他車の見た目には影響しない。
+    updateShellVisibility(mesh, vehicle);
   }
 }


### PR DESCRIPTION
## 変更内容

一部の車種でドライバー視点のカメラが車体にめり込み、視界が遮られていた問題を修正した。手動操作でカメラを寄せた場合にも同じ干渉が起きるため、視点の種類で分岐せず「カメラが車体内部に入った時」という条件で一律に処理している。

- `VehicleMesh` に `shellParts`（`body` / `glass` / `trim` / `cargo`、タクシーの行灯を含む車体シェル）の参照を持たせた。`addPart()` が生成した `THREE.Mesh` を返すようにして収集する。
- `updateVehicleCameraOcclusion(world)` を追加。カメラのワールド座標を各車両のローカル座標へ変換し、車体の骨組みより上（`y > 0.55` かつ 車高 + 0.9 未満、幅・長さは余裕を持たせた範囲内）に入っているかを判定して、入っている間だけシェルを `visible = false` にする。
- `src/app.ts` の描画ループで `updateCamera()` の直後、`renderer.render()` の前に `updateVehicleCameraOcclusion(world)` を呼ぶ。
- 待機中（`vehicle.waiting`）の車両はシェルを常に表示に戻す。

タイヤ・ハブ・ナンバープレート・灯火類は非表示の対象外なので、車体だけが消えて骨組みは残る見た目になる。表示状態は車両ごとの描画グループに閉じており、交通挙動や他車の見た目には影響しない。

変更は `src/render/vehicle-mesh.ts` と `src/app.ts` のみで、`src/core/` のシミュレーションロジックには触れていない。

## 検証結果

`.claude/worktrees/codex-45` にて実行。

- `pnpm test`

```
 Test Files  1 passed (1)
      Tests  49 passed (49)
```

- `pnpm exec tsc --noEmit`

```
TypeScript: No errors found
```

いずれも `origin/main` のベースラインと同一（テスト 1 ファイル / 49 件、型エラー 0）。

Closes #45
