### PR TITLE
影カメラ範囲を道路全体に合わせる

### DIFF
--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,5 +1,6 @@
 /* ================= Three.js セットアップ(シーン・カメラ・ライト) ================= */
 import * as THREE from 'three';
+import { CONST } from '../core';
 import { makeGrassTexture } from './materials';
 
 export const SKY_COLOR = 0xcfe2ee;
@@ -28,16 +29,46 @@ document.getElementById('container')!.appendChild(renderer.domElement);
 export const hemiLight = new THREE.HemisphereLight(0xeaf4ff, 0x55694f, 0.85);
 scene.add(hemiLight);
 export const sun = new THREE.DirectionalLight(0xfff3df, 0.95);
-sun.position.set(70, 130, 50);
+const sunDirection = new THREE.Vector3(70, 130, 50).normalize();
+sun.position.copy(sunDirection).multiplyScalar(420);
 sun.castShadow = true;
-sun.shadow.mapSize.set(2048, 2048);
-sun.shadow.camera.left = -170;
-sun.shadow.camera.right = 170;
-sun.shadow.camera.top = 220;
-sun.shadow.camera.bottom = -220;
-sun.shadow.camera.near = 20;
-sun.shadow.camera.far = 500;
-sun.shadow.bias = -0.0006;
+// three r128 の LightShadow.updateMatrices() は shadow.camera.lookAt() で光源から target を向く。
+// そのため left/right はワールド X ではなくシャドウカメラのローカル X 軸に対応する。
+// up を光軸とワールド Z の両方に直交する向きへ回し、ローカル X を道路長手方向 Z に揃える。
+// バージョンアップで LightShadow の lookAt() 前提が変わると、この軸合わせも再確認が必要。
+sun.shadow.camera.up
+  .copy(sunDirection)
+  .cross(new THREE.Vector3(0, 0, 1))
+  .normalize();
+const shadowAxisX = new THREE.Vector3()
+  .crossVectors(sun.shadow.camera.up, sunDirection)
+  .normalize();
+const shadowAxisY = sun.shadow.camera.up.clone();
+const shadowAxisZ = sunDirection.clone();
+// 並木は scenery.ts で x = ±(22 + rand^1.6 * 70) なので最大 ±92m。
+// 樹冠と端部の余裕を含め、道路全体を覆う直方体として扱う。
+const shadowBoundsHalfSize = new THREE.Vector3(100, 14, CONST.ROAD_HALF + 24);
+function shadowHalfExtent(axis: THREE.Vector3): number {
+  return (
+    Math.abs(axis.x) * shadowBoundsHalfSize.x +
+    Math.abs(axis.y) * shadowBoundsHalfSize.y +
+    Math.abs(axis.z) * shadowBoundsHalfSize.z
+  );
+}
+const shadowHalfWidth = shadowHalfExtent(shadowAxisX);
+const shadowHalfHeight = shadowHalfExtent(shadowAxisY);
+const shadowHalfDepth = shadowHalfExtent(shadowAxisZ);
+sun.shadow.mapSize.set(4096, 1024);
+// WebGL の MAX_TEXTURE_SIZE 保証値は 2048。上限が低い端末では three が 2048x1024 へ縮める。
+sun.shadow.camera.left = -shadowHalfWidth;
+sun.shadow.camera.right = shadowHalfWidth;
+sun.shadow.camera.top = shadowHalfHeight;
+sun.shadow.camera.bottom = -shadowHalfHeight;
+sun.shadow.camera.near = Math.max(1, sun.position.length() - shadowHalfDepth);
+sun.shadow.camera.far = sun.position.length() + shadowHalfDepth;
+sun.shadow.camera.updateProjectionMatrix();
+sun.shadow.bias = -0.00035;
+sun.shadow.normalBias = 0.025;
 scene.add(sun);
 
 /* ---- 地面（草地。背景の透け防止のため広く・低く配置） ---- */


### PR DESCRIPTION
## 変更内容

- `DirectionalLight` の向きは `(70, 130, 50)` のまま、距離だけを 420m に伸ばしました。
- three r128 の `LightShadow.updateMatrices()` が `shadow.camera.lookAt()` で向きを作る前提に合わせ、`shadow.camera.up` を `normalize(cross(sunDir, +Z))` に設定しました。
- `left/right/top/bottom/near/far` は直書きせず、太陽方向と覆う直方体半径から `shadowHalfExtent(axis) = |a.x|HX + |a.y|HY + |a.z|HZ` で導出しました。
- `mapSize` は 4096x1024 にし、総テクセル数は従来の 2048x2048 と同じにしました。`bias` は `-0.00035`、`normalBias` は `0.025` に調整しました。

## 導出根拠

- 太陽方向: `normalize(70, 130, 50) = (0.4491, 0.8340, 0.3208)`
- 回転後 up: `normalize(cross(sunDir, +Z)) = (0.8805, -0.4741, 0)`
- 回転後ローカル X: `cross(up, sunDir) = (-0.1521, -0.2824, 0.9472)` なので、`left/right` が道路長手方向 Z にほぼ揃います。
- 覆う直方体半径: `HX=100`, `HY=14`, `HZ=ROAD_HALF + 24 = 424`
  - 並木は `scenery.ts` の `x = ±(22 + rand^1.6 * 70)` で最大 ±92m。樹冠と端部の余裕を含めて X 半径 100m としました。
- 導出結果:
  - `left/right = ±420.76`
  - `top/bottom = ±94.68`
  - 深度半径 `192.58`
  - `near = 420 - 192.58 = 227.42`
  - `far = 420 + 192.58 = 612.58`
  - テクセル実寸: `420.76*2/4096 = 0.2054m`, `94.68*2/1024 = 0.1849m`

## 先行実装が誤りだった理由

three r128 のシャドウカメラは `lookAt(target)` で向くため、正投影カメラの `left/right` と `top/bottom` はワールド X/Z にそのまま対応しません。既定 up のままだとローカル X は `(0.5812, 0, -0.8137)` で、`left/right` が主に道路長手方向 Z を切ります。

そのため `left/right = ±260` に広げても、実際には `|z| ≒ 306〜333` 付近で影が打ち切られ、道路 `±400` の端部には影が届きませんでした。今回の変更では up を回してローカル X を Z 方向へ揃えたうえで、必要範囲を軸ごとに導出しています。

## 検証

- `pnpm check`
  - `pass: All 34 files are correctly formatted`
  - `pass: Found no warnings, lint errors, or type errors in 26 files`
- `pnpm test`
  - `Test Files 1 passed (1)`
  - `Tests 49 passed (49)`
- dev server: `pnpm dev --host 127.0.0.1 --port 5283` を使用し、検証後に停止しました。
- スクリーンショット:
  - `/tmp/traffic-jam-simulation-issue-56-screenshots/before-z-plus-380.png`
  - `/tmp/traffic-jam-simulation-issue-56-screenshots/before-z-minus-380.png`
  - `/tmp/traffic-jam-simulation-issue-56-screenshots/after-z-plus-380.png`
  - `/tmp/traffic-jam-simulation-issue-56-screenshots/after-z-minus-380.png`
- before では `z=+380` 付近の手前側で並木・道路端の影が消えていることを確認しました。
- after では同じ遠方画角で左右の並木と道路端の影が残り、L区間/R区間で打ち切り位置に差が出ていないことを確認しました。

Closes #56