### PR TITLE
オートモードのカメラ切替時刻を外周表示する

### DIFF
--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -240,6 +240,18 @@ function notify(): void {
   changeListener?.(getSpectatorStatus());
 }
 
+type SpectatorProgressListener = (progress: number) => void;
+let progressListener: SpectatorProgressListener | null = null;
+/** 自動巡回の次の視点切替までの進捗を 0〜1 で通知する */
+export function onSpectatorProgress(listener: SpectatorProgressListener): void {
+  progressListener = listener;
+  listener(
+    spectator.modeIndex === AUTO_MODE_INDEX
+      ? clamp(spectator.cycleTimer / AUTO_CYCLE_INTERVAL, 0, 1)
+      : 0,
+  );
+}
+
 // 今の姿勢を起点にして、目標姿勢への補間をやり直す
 function beginTransition(): void {
   spectator.transitionTime = 0;
@@ -252,6 +264,7 @@ function switchPreset(index: number): void {
   spectator.presetIndex = (index + SPECTATOR_PRESETS.length) % SPECTATOR_PRESETS.length;
   spectator.presetTime = 0;
   spectator.cycleTimer = 0;
+  progressListener?.(0);
   beginTransition();
   followVehicle = null; // プリセットが変わったら追尾対象は選び直す
   followChanged = false;
@@ -279,6 +292,7 @@ function setMode(index: number): void {
     // マニュアルモードへ戻す。今の見え方をそのまま軌道パラメータへ引き継ぐ
     syncOrbitFromCamera();
     followVehicle = null;
+    progressListener?.(0);
   } else if (spectator.modeIndex === AUTO_MODE_INDEX) {
     // オートモードは先頭のプリセットから始める
     switchPreset(0);
@@ -307,6 +321,7 @@ function updateSpectator(world: World, deltaTime: number): void {
       // プリセットごとに表示が入れ替わるとうるさいため (Issue #43)
       switchPreset(spectator.presetIndex + 1);
     }
+    progressListener?.(clamp(spectator.cycleTimer / AUTO_CYCLE_INTERVAL, 0, 1));
   }
   SPECTATOR_PRESETS[spectator.presetIndex].compute(goalPose, {
     time: spectator.presetTime,

--- a/src/style.css
+++ b/src/style.css
@@ -434,6 +434,7 @@ body.night #nightBtn {
    専用パネルではなく丸ボタン1つに集約しているため、
    画面が狭くても他のパネル(スコア比較・コントロール)と干渉しない */
 #spectatorBtn {
+  --auto-cycle-progress: 0;
   position: fixed;
   top: 78px;
   right: 14px;
@@ -460,6 +461,28 @@ body.night #nightBtn {
     transform 0.18s ease,
     box-shadow 0.3s ease,
     background 0.3s ease;
+}
+/* 自動巡回中は、次の視点切替までの進捗を外周が一周する光で示す */
+#spectatorBtn.auto::before {
+  content: '';
+  position: absolute;
+  inset: -7px;
+  border-radius: 50%;
+  pointer-events: none;
+  background: conic-gradient(
+    from -90deg,
+    #ffe88a calc(var(--auto-cycle-progress) * 1turn),
+    rgba(255, 213, 74, 0.16) 0
+  );
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 4px), #000 0);
+  mask: radial-gradient(farthest-side, transparent calc(100% - 4px), #000 0);
+  filter: drop-shadow(0 0 4px rgba(255, 213, 74, 0.72));
+}
+@media (prefers-reduced-motion: reduce) {
+  #spectatorBtn.auto::before {
+    /* 動きを抑える設定では、進捗アニメーションの代わりに静止した一周表示にする */
+    background: #ffd54a;
+  }
 }
 #spectatorBtn .lucide {
   width: 26px;

--- a/src/ui/spectator.ts
+++ b/src/ui/spectator.ts
@@ -3,7 +3,12 @@
    そこでカラーモード切替と同じ「押すたびに切り替わる丸ボタン」1つに集約し、
    マニュアル → オート → 各プリセット → マニュアル… と循環させる。
    カメラ状態そのものは render/camera.ts が持ち、ここは操作と表示だけを行う。 */
-import { cycleSpectatorMode, getSpectatorStatus, onSpectatorChange } from '../render/camera';
+import {
+  cycleSpectatorMode,
+  getSpectatorStatus,
+  onSpectatorChange,
+  onSpectatorProgress,
+} from '../render/camera';
 import type { SpectatorStatus } from '../render/camera';
 import { icon, renderIcons } from './icons';
 
@@ -18,6 +23,7 @@ export function setupSpectator(): void {
     // アイコンは「今どのモードか」を表す
     button.innerHTML = icon(status.mode.icon);
     button.classList.toggle('on', status.enabled);
+    button.classList.toggle('auto', status.auto);
     label.textContent = status.mode.label;
     label.classList.toggle('show', showLabel);
     clearTimeout(labelTimer);
@@ -34,5 +40,8 @@ export function setupSpectator(): void {
 
   button.addEventListener('click', cycleSpectatorMode);
   onSpectatorChange((status) => render(status, true));
+  onSpectatorProgress((progress) => {
+    button.style.setProperty('--auto-cycle-progress', String(progress));
+  });
   render(getSpectatorStatus(), false);
 }


### PR DESCRIPTION
## 概要

オートモードで次のカメラ切替までの進捗を、観賞モードボタンの外周を一周するハイライトとして表示します。

## 変更内容

- カメラの自動巡回タイマーから0〜1の進捗をUIへ通知
- 自動巡回中のみ、ボタン外周へ時計回りの進捗リングを表示
- モード終了・プリセット切替・再入場時に進捗を同期的にリセット
- `prefers-reduced-motion` 有効時は、動かない一周リングで自動モードを表示
- 先行実装の一時ラベル表示とデフォルト自動モードの挙動を維持

## 影響

実際のカメラ切替タイマーと同じ値を使用するため、表示と切替時刻がずれません。L/R区間の車両挙動やシミュレーションコアには変更ありません。

## 確認

- `pnpm check`
- `pnpm test`（53件成功）
- `pnpm build`
- Chromiumで進捗増加、切替・終了・再入場時のリセット、reduced-motion時の静止表示を確認
- ブラウザコンソールエラー0件
- 最新 `main` へのrebase後に独立コードレビュー済み

Closes #65