### PR TITLE
HUDの車両数上限を実装値に合わせる

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
       </div>
       <div class="panel-body">
         <div class="row">
-          総車両数: <span class="num" id="vehicleCount">0</span> / <span class="num">200</span>
+          総車両数: <span class="num" id="vehicleCount">0</span> /
+          <span class="num" id="maxVehicleCount"></span>
         </div>
         <div class="row">
           車両ペア生成間隔: <span class="num" id="intervalLabel">800</span> ms

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -9,6 +9,7 @@ function byId<T extends HTMLElement = HTMLElement>(id: string): T {
 
 export const elements = {
   count: byId('vehicleCount'),
+  maxCount: byId('maxVehicleCount'),
   intervalLabel: byId('intervalLabel'),
   slider: byId<HTMLInputElement>('intervalSlider'),
   countLeft: byId('countLeft'),
@@ -30,6 +31,8 @@ export const elements = {
   smoothBarLeft: byId('smoothBarLeft'),
   smoothLead: byId('smoothLead'),
 };
+
+elements.maxCount.textContent = String(CONST.MAX_VEHICLES);
 
 // 渋滞スコアに応じた状態(段階が変わった時だけ DOM を書き換えてアイコンを再生成)
 function statusTier(score: number): { icon: string; label: string } {


### PR DESCRIPTION
## 概要

- HUDの総車両数の分母を、ハードコードされた`200`から実装上の上限値`CONST.MAX_VEHICLES`へ連動させました。
- 上限値の変更時にもHUD表示が自動的に追従します。

## 原因

HUDの分母だけがHTMLに`200`として直書きされており、実際の最大車両数`280`と乖離していました。そのため、混雑時に`201 / 200`のような表示が発生していました。

## 影響

表示のみの変更です。シミュレーションの物理挙動、L/R区間の条件、車両生成上限には変更ありません。

## 検証

- `pnpm check`
- `pnpm test`（53件成功）
- `pnpm build`
- PlaywrightでHUDが`138 / 280`と表示され、車両数更新後も分母`280`が維持されることを確認
- ブラウザコンソールエラー0件
- 独立コードレビュー済み

Closes #55