### PR TITLE
雲のテクスチャを自然な輪郭にする

### DIFF
--- a/src/render/materials.ts
+++ b/src/render/materials.ts
@@ -200,8 +200,59 @@ export const mountainNearMaterial = new THREE.MeshBasicMaterial({
 });
 
 /* ---- 雲(昼のみ。夜はthemeがフェードアウト) ---- */
+function makeCloudTexture(): THREE.CanvasTexture {
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 128;
+  const ctx = canvas.getContext('2d')!;
+
+  // ひと続きの輪郭で、丸いスプライトを重ねたような継ぎ目を出さない。
+  const cloud = new Path2D();
+  cloud.moveTo(18, 91);
+  cloud.bezierCurveTo(13, 76, 25, 64, 43, 64);
+  cloud.bezierCurveTo(46, 46, 62, 35, 80, 39);
+  cloud.bezierCurveTo(88, 19, 112, 12, 130, 29);
+  cloud.bezierCurveTo(148, 21, 170, 31, 174, 50);
+  cloud.bezierCurveTo(192, 43, 212, 53, 213, 70);
+  cloud.bezierCurveTo(235, 69, 246, 82, 238, 96);
+  cloud.bezierCurveTo(226, 111, 45, 112, 25, 101);
+  cloud.bezierCurveTo(21, 99, 19, 95, 18, 91);
+  cloud.closePath();
+
+  ctx.save();
+  ctx.filter = 'blur(3px)';
+  const body = ctx.createLinearGradient(0, 18, 0, 108);
+  body.addColorStop(0, 'rgba(255,255,255,0.98)');
+  body.addColorStop(0.62, 'rgba(249,251,252,0.94)');
+  body.addColorStop(1, 'rgba(214,225,231,0.68)');
+  ctx.fillStyle = body;
+  ctx.fill(cloud);
+  ctx.restore();
+
+  // 上面だけに淡いハイライトを重ね、平板な白い板に見えないようにする。
+  ctx.save();
+  ctx.clip(cloud);
+  ctx.filter = 'blur(6px)';
+  for (const [x, y, radius] of [
+    [78, 49, 31],
+    [126, 36, 38],
+    [171, 53, 30],
+  ]) {
+    const highlight = ctx.createRadialGradient(x, y, 2, x, y, radius);
+    highlight.addColorStop(0, 'rgba(255,255,255,0.72)');
+    highlight.addColorStop(1, 'rgba(255,255,255,0)');
+    ctx.fillStyle = highlight;
+    ctx.fillRect(x - radius, y - radius, radius * 2, radius * 2);
+  }
+  ctx.restore();
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.generateMipmaps = true;
+  return texture;
+}
+
 export const cloudMaterial = new THREE.SpriteMaterial({
-  map: makeGlowTexture('rgba(255,255,255,0.85)', 'rgba(255,255,255,0)'),
+  map: makeCloudTexture(),
   transparent: true,
   depthWrite: false,
   fog: false,

--- a/src/render/scenery.ts
+++ b/src/render/scenery.ts
@@ -117,18 +117,24 @@ const ROAD_HALF = CONST.ROAD_HALF;
     const centerX = Math.cos(theta) * radius,
       centerZ = Math.sin(theta) * radius,
       centerY = 150 + Math.random() * 110;
+    let width = 0,
+      aspect = 0;
     for (let k = 0; k < 3; k++) {
-      // ひと塊を3枚のスプライトでもこもこに
-      const sprite = new THREE.Sprite(cloudMaterial);
-      const width = 90 + Math.random() * 120;
-      sprite.scale.set(width, width * (0.28 + Math.random() * 0.14), 1);
-      sprite.position.set(
-        centerX + (Math.random() - 0.5) * 70,
-        centerY + (Math.random() - 0.5) * 18,
-        centerZ + (Math.random() - 0.5) * 70,
-      );
-      sprite.renderOrder = -14;
-      scene.add(sprite);
+      // 後続の星・車両外観の乱数列を変えないよう、旧3枚構成と同じ順序・回数で消費する。
+      const widthRandom = Math.random(),
+        aspectRandom = Math.random();
+      Math.random(); // 房ごとのXずれ
+      Math.random(); // 房ごとのYずれ
+      Math.random(); // 房ごとのZずれ
+      if (k === 0) {
+        width = 130 + widthRandom * 130;
+        aspect = 0.32 + aspectRandom * 0.08;
+      }
     }
+    const sprite = new THREE.Sprite(cloudMaterial);
+    sprite.scale.set(width, width * aspect, 1);
+    sprite.position.set(centerX, centerY, centerZ);
+    sprite.renderOrder = -14;
+    scene.add(sprite);
   }
 })();


### PR DESCRIPTION
## 概要

Issue #44 の雲を、ぼけた円形スプライトの重ね合わせから、一体感のある自然な輪郭へ変更します。

## 変更内容

- 256×128 の雲専用 `CanvasTexture` を追加
- `Path2D` の連続した輪郭、上下のグラデーション、上面の淡いハイライトで立体感を表現
- 1つの雲を3枚のスプライトで構成していた実装を、共有material/textureを使う1枚のスプライトへ変更
- 雲の配置数・遠景半径・高度と、昼夜テーマのフェード処理は維持

## 効果

- 丸いぼかしの寄せ集め感とスプライト間の継ぎ目を解消
- 雲の描画オブジェクト数を27から9へ削減
- 透明な矩形境界やテクスチャの反復継ぎ目を発生させない構成
- 完全な夜では従来どおり雲が消え、星空を遮らない

## 乱数列の互換性

後続の星や車両外観へ影響しないよう、旧実装と同じ順序で1雲あたり18回、9雲合計162回の `Math.random` を消費します。最初の房の幅・縦横比の標本だけを単一スプライトの寸法へ再利用しており、乱数の追加や並べ替えはありません。実コードの `buildClouds` をMath.random spyで実行し、18回/雲・162回合計を確認しました。

## 確認

- `pnpm check`: pass
- `pnpm test`: 53 tests passed
- `pnpm build`: pass
- Chromiumで昼・昼夜遷移中・完全な夜を確認
- console error: 0
- スクリーンショット取得時のWebGL `ReadPixels` 警告以外に警告なし
- 独立コードレビュー済み

Closes #44