### PR TITLE
Vitest の対象から .claude 配下の worktree を除外

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite-plus';
+import { configDefaults } from 'vitest/config';
 
 export default defineConfig({
   // 相対パスで出力する: dist/ をどのパス(サブディレクトリ配信・file://)に
@@ -23,6 +24,13 @@ export default defineConfig({
   test: {
     // シミュレーションを実時間で数百秒ぶん回すシナリオテストがあるため長め
     testTimeout: 300_000,
+    // `.claude/worktrees/` には並行作業用の git worktree が置かれており、
+    // 各 worktree にもテストファイル (traffic-simulation.test.ts) が存在する。
+    // 除外しないとリポジトリルートでの実行時に他 worktree の古いコードのテストまで
+    // glob されてしまい、テスト件数が worktree の増減で変動して再現しなくなる。
+    // exclude を指定すると Vitest の既定値は置き換わるため、configDefaults.exclude
+    // (node_modules / .git) を展開して打ち消さないようにする。
+    exclude: [...configDefaults.exclude, '**/.claude/**'],
   },
   // コミット時 (pre-commit hook → `vp staged`) にステージ済みファイルをフォーマットする。
   // hooks 本体は `vp config` (pnpm install の prepare で自動実行) が .vite-hooks に導入する


### PR DESCRIPTION
## 問題

`vite.config.ts` の `test` セクションに `exclude` 指定がなかったため、リポジトリルートで `pnpm test` を実行すると Vitest が `.claude/worktrees/` 配下の並行作業用 git worktree にあるテストファイルまで glob して実行していました。

- リポジトリが追跡するテストファイルはルートの `traffic-simulation.test.ts` 1 個だけです（`git ls-tree -r origin/main` で確認）。
- しかしルートでの実行結果は worktree の個数に応じて変動し、実測で 28 files / 1224 tests（別のタイミングでは 27 files / 1175 tests）になっていました。
- 他 worktree の古いコードのテストが現在の作業ツリーのテストとして実行されるため、テスト結果が再現しません。

## 修正

`configDefaults.exclude` を展開したうえで `.claude/**` パターンを追加しました。
`include` は無指定のままデフォルトを維持しています。

## 検証結果

- ルートと同一のグロブ条件で修正後の設定を適用した実行: 28 files / 1224 tests → 1 file / 49 tests
- 修正ブランチの worktree 内: Test Files 1 passed (1) / Tests 49 passed (49)
- `pnpm check`: pass: All 34 files are correctly formatted / pass: Found no warnings, lint errors, or type errors in 26 files
- デフォルト exclude を打ち消していないことを確認済みです。本リポジトリの Vitest 4.1.10 では `configDefaults.exclude` は `node_modules` と `.git` の2件のみです（v3系にあった `dist` / `.idea` / `.cache` は v4 で既定から外れています）。解決後の値は `node_modules`、`.git`、`.claude` の3件で、既定2件が保持されています。
- `include` を過度に狭めていないことを picomatch で検証済みです。`traffic-simulation.test.ts` / `src/core/vehicle.test.ts` / `src/foo/bar/baz.spec.tsx` / `src/core/sim.test.mts` は収集され、`.claude/worktrees/agent-x` 配下のテストファイル、`node_modules` 配下、`.git` 配下のテストファイルは除外されます。

## 今後の検討事項

- `.claude` 配下全体を除外するパターンのため、将来 `.claude/` 内に実行したいテスト（フックやスキルの自前テスト等）を置くと拾われません。`.claude/worktrees` 配下に絞る選択肢もありますが、worktree 以外のチェックアウトが `.claude/` に増える可能性を考えて広めにしています。
- ルートに未追跡で存在する `.playwright-cli/` は除外していません。現状テストファイルがないため影響はありませんが、将来 `*.test.ts` が置かれると拾われます。