### PR TITLE
fix: 周回境界で道路が途切れないようにする

### DIFF
--- a/src/render/looping.ts
+++ b/src/render/looping.ts
@@ -1,0 +1,9 @@
+/* ================= 周回路の描画補助 =================
+   シミュレーション上の周回境界の前後にも同じ静的設備を配置し、
+   車両固定の視点で道路が途切れて見えるのを防ぐ。 */
+import { WRAP_LENGTH } from '../core';
+
+/** 基準位置と、その前後1周ぶんの複製位置を返す。 */
+export function loopCopies(z: number): [number, number, number] {
+  return [z - WRAP_LENGTH, z, z + WRAP_LENGTH];
+}

--- a/src/render/scenery.ts
+++ b/src/render/scenery.ts
@@ -2,10 +2,11 @@
    道路施設(track.js)とは別の「風景」を担当する。
    山・雲のマテリアルは materials.js にあり、昼夜の色は theme.js が補間する */
 import * as THREE from 'three';
-import { CONST } from '../core';
+import { CONST, WRAP_LENGTH } from '../core';
 import { scene } from './scene';
 import { mountainFarMaterial, mountainNearMaterial, cloudMaterial } from './materials';
 import { instancedAt } from './instancing';
+import { loopCopies } from './looping';
 
 const ROAD_HALF = CONST.ROAD_HALF;
 
@@ -16,10 +17,13 @@ const ROAD_HALF = CONST.ROAD_HALF;
   const postGeometry = new THREE.BoxGeometry(0.12, 0.8, 0.12);
   const postPositions: [number, number, number][] = [];
   for (const side of [-1, 1]) {
-    const rail = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.3, ROAD_HALF * 2), railMaterial);
-    rail.position.set(18.2 * side, 0.62, 0);
-    scene.add(rail);
-    for (let z = -ROAD_HALF + 4; z < ROAD_HALF; z += 12) postPositions.push([18.2 * side, 0.4, z]);
+    for (const offset of loopCopies(0)) {
+      const rail = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.3, WRAP_LENGTH), railMaterial);
+      rail.position.set(18.2 * side, 0.62, offset);
+      scene.add(rail);
+      for (let z = -WRAP_LENGTH / 2 + 4; z < WRAP_LENGTH / 2; z += 12)
+        postPositions.push([18.2 * side, 0.4, z + offset]);
+    }
   }
   scene.add(instancedAt(postGeometry, postMaterial, postPositions));
   // 遮音壁: 下段コンクリート + 上段の半透明パネル(高速道路らしさ)

--- a/src/render/track.ts
+++ b/src/render/track.ts
@@ -1,12 +1,11 @@
 /* ================= 道路・標識などの静的な情景 ================= */
 import * as THREE from 'three';
-import { CONST } from '../core';
+import { CONST, WRAP_LENGTH } from '../core';
 import type { Section } from '../core';
 import { scene } from './scene';
 import { delineatorMaterial, asphaltTexture } from './materials';
 import { instancedAt, instancedWith } from './instancing';
-
-const ROAD_HALF = CONST.ROAD_HALF;
+import { loopCopies } from './looping';
 
 /* ---- 区間テーマカラー(どの角度から見ても区別できるように) ---- */
 export interface SectionTheme {
@@ -45,35 +44,41 @@ export function sectionX(section: Section, xInSectionFrame: number): number {
 
 /* ---- 道路(アスファルト質感 + 区間ごとの色味) ---- */
 for (const section of SECTIONS) {
-  const road = new THREE.Mesh(
-    new THREE.BoxGeometry(13.2, 0.12, ROAD_HALF * 2),
-    new THREE.MeshLambertMaterial({ color: SECTION_THEME[section].road, map: asphaltTexture }),
-  );
-  road.position.set(sectionX(section, -7), -0.06, 0);
-  road.receiveShadow = true;
-  scene.add(road);
-  // 進行方向左側(加速車線側)の路肩ライン(テーマカラー)
-  const strip = new THREE.Mesh(
-    new THREE.BoxGeometry(0.7, 0.06, ROAD_HALF * 2),
-    new THREE.MeshBasicMaterial({ color: SECTION_THEME[section].strip }),
-  );
-  strip.position.set(sectionX(section, -14.1), -0.03, 0);
-  scene.add(strip);
+  for (const z of loopCopies(0)) {
+    const road = new THREE.Mesh(
+      new THREE.BoxGeometry(13.2, 0.12, WRAP_LENGTH),
+      new THREE.MeshLambertMaterial({ color: SECTION_THEME[section].road, map: asphaltTexture }),
+    );
+    road.position.set(sectionX(section, -7), -0.06, z);
+    road.receiveShadow = true;
+    scene.add(road);
+    // 進行方向左側(加速車線側)の路肩ライン(テーマカラー)
+    const strip = new THREE.Mesh(
+      new THREE.BoxGeometry(0.7, 0.06, WRAP_LENGTH),
+      new THREE.MeshBasicMaterial({ color: SECTION_THEME[section].strip }),
+    );
+    strip.position.set(sectionX(section, -14.1), -0.03, z);
+    scene.add(strip);
+  }
 }
 
 /* ---- 車線マーキング ---- */
 const whiteLineMaterial = new THREE.MeshBasicMaterial({ color: 0xf2f2f2 });
 function solidLine(x: number): void {
-  const mesh = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.02, ROAD_HALF * 2), whiteLineMaterial);
-  mesh.position.set(x, 0.01, 0);
-  scene.add(mesh);
+  for (const z of loopCopies(0)) {
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.02, WRAP_LENGTH), whiteLineMaterial);
+    mesh.position.set(x, 0.01, z);
+    scene.add(mesh);
+  }
 }
 // 車線境界の破線は全車線ぶんを1つのInstancedMeshに(draw call削減)
 function dashedLines(xPositions: number[]): void {
   const geometry = new THREE.BoxGeometry(0.15, 0.02, 4);
   const positions: [number, number, number][] = [];
   for (const x of xPositions)
-    for (let z = -ROAD_HALF + 2; z < ROAD_HALF; z += 12) positions.push([x, 0.01, z]);
+    for (const offset of loopCopies(0))
+      for (let z = -WRAP_LENGTH / 2 + 2; z < WRAP_LENGTH / 2; z += 12)
+        positions.push([x, 0.01, z + offset]);
   scene.add(instancedAt(geometry, whiteLineMaterial, positions));
 }
 for (const section of SECTIONS) for (const x of [-1, -13]) solidLine(sectionX(section, x));
@@ -119,29 +124,32 @@ for (const section of SECTIONS) {
    両区間は同じ向きに走る独立した道路なので「中央分離帯」ではなく、
    L区間の右路肩と R区間の加速車線の間に立つ仕切りの防護柵 */
 (function buildDivider() {
-  const base = new THREE.Mesh(
-    new THREE.BoxGeometry(0.8, 0.5, ROAD_HALF * 2),
-    new THREE.MeshLambertMaterial({ color: 0x9aa0a6 }),
-  );
-  base.position.set(0, 0.25, 0);
-  base.castShadow = true;
-  base.receiveShadow = true;
-  scene.add(base);
+  const baseGeometry = new THREE.BoxGeometry(0.8, 0.5, WRAP_LENGTH);
+  const baseMaterial = new THREE.MeshLambertMaterial({ color: 0x9aa0a6 });
   const railMaterial = new THREE.MeshLambertMaterial({ color: 0xe9edf0 });
-  for (const railX of [-0.3, 0.3]) {
-    const rail = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.14, ROAD_HALF * 2), railMaterial);
-    rail.position.set(railX, 0.95, 0);
-    scene.add(rail);
+  for (const z of loopCopies(0)) {
+    const base = new THREE.Mesh(baseGeometry, baseMaterial);
+    base.position.set(0, 0.25, z);
+    base.castShadow = true;
+    base.receiveShadow = true;
+    scene.add(base);
+    for (const railX of [-0.3, 0.3]) {
+      const rail = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.14, WRAP_LENGTH), railMaterial);
+      rail.position.set(railX, 0.95, z);
+      scene.add(rail);
+    }
   }
   const postGeometry = new THREE.BoxGeometry(0.12, 0.55, 0.12);
   const delineatorGeometry = new THREE.BoxGeometry(0.16, 0.16, 0.06); // 視線誘導標(デリネーター)
   const postPositions: [number, number, number][] = [];
   const delineatorPositions: [number, number, number][] = [];
-  for (let z = -ROAD_HALF + 6; z < ROAD_HALF; z += 18) {
-    postPositions.push([0, 0.75, z]);
-    // 両進行方向から見えるよう両面に
-    for (const offsetZ of [-0.09, 0.09]) delineatorPositions.push([0, 1.12, z + offsetZ]);
-  }
+  for (const offset of loopCopies(0))
+    for (let z = -WRAP_LENGTH / 2 + 6; z < WRAP_LENGTH / 2; z += 18) {
+      postPositions.push([0, 0.75, z + offset]);
+      // 両進行方向から見えるよう両面に
+      for (const offsetZ of [-0.09, 0.09])
+        delineatorPositions.push([0, 1.12, z + offset + offsetZ]);
+    }
   scene.add(instancedAt(postGeometry, railMaterial, postPositions));
   scene.add(instancedAt(delineatorGeometry, delineatorMaterial, delineatorPositions));
 })();

--- a/src/render/vehicle-mesh.ts
+++ b/src/render/vehicle-mesh.ts
@@ -23,6 +23,7 @@ import {
   beamGeometry,
 } from './materials';
 import { themeState } from './theme';
+import { loopCopies } from './looping';
 
 // ドライバーの「手癖」(描画上の個性)。実際の車は車線の中央ぴったりを走らない。
 // 車線内の定位置(左寄り/右寄り)、無意識の蛇行の周期・振幅、修正舵の細かさは
@@ -41,11 +42,13 @@ interface DriverHabit {
 
 export interface VehicleMesh {
   group: THREE.Group;
+  loopGroups: THREE.Group[];
   shellParts: THREE.Mesh[];
   brakeMaterial: THREE.MeshBasicMaterial;
   blinkLeft: THREE.MeshBasicMaterial;
   blinkRight: THREE.MeshBasicMaterial;
   beam: THREE.Mesh;
+  loopBeams: THREE.Mesh[];
   beamDistance: number;
   brakeGlow: THREE.Mesh;
   previousX: number;
@@ -507,6 +510,23 @@ function buildVehicleMesh(vehicle: Vehicle): VehicleMesh {
   brakeGlow.updateMatrix();
   brakeGlow.visible = false;
   group.add(brakeGlow);
+  // 周回境界の前後に置く表示専用コピー。Vehicle とは紐付けず、描画だけを複製する。
+  const loopGroups = loopCopies(0)
+    .filter((offset) => offset !== 0)
+    .map((offset) => {
+      const copy = group.clone(true);
+      copy.position.z = offset;
+      scene.add(copy);
+      return copy;
+    });
+  const loopBeams = loopCopies(0)
+    .filter((offset) => offset !== 0)
+    .map((offset) => {
+      const copy = beam.clone();
+      copy.position.z = offset;
+      scene.add(copy);
+      return copy;
+    });
   const bodyWidth = vehicle.type.width;
   const margin = Math.max(0, (3.7 - bodyWidth) / 2 - 0.42); // 車線内で安全に振れる余白
   const habit: DriverHabit = {
@@ -522,11 +542,13 @@ function buildVehicleMesh(vehicle: Vehicle): VehicleMesh {
   };
   return {
     group,
+    loopGroups,
     shellParts,
     brakeMaterial,
     blinkLeft,
     blinkRight,
     beam,
+    loopBeams,
     beamDistance,
     brakeGlow,
     previousX: vehicle.x + habit.bias,
@@ -564,8 +586,10 @@ export function syncMeshes(world: World, deltaTime: number): void {
       scene.add(mesh.group);
     }
     mesh.group.visible = !vehicle.waiting;
+    for (const copy of mesh.loopGroups) copy.visible = !vehicle.waiting;
     if (vehicle.waiting) {
       mesh.beam.visible = false;
+      for (const beam of mesh.loopBeams) beam.visible = false;
       continue;
     }
     // ---- ハンドル操作の個性: 定位置のズレ + 無意識の蛇行(速度が低いほど収まる) ----
@@ -578,6 +602,10 @@ export function syncMeshes(world: World, deltaTime: number): void {
     const amplitude = habit.swayAmplitude * (0.25 + 0.75 * clamp(vehicle.speed / 25, 0, 1));
     const x = vehicle.x + habit.bias + sway * amplitude;
     mesh.group.position.set(x, 0, vehicle.z);
+    const copyZs = loopCopies(vehicle.z).filter((z) => z !== vehicle.z);
+    mesh.loopGroups.forEach((copy, index) => {
+      copy.position.set(x, 0, copyZs[index]);
+    });
     const lateralVelocity = deltaTime > 0 ? (x - mesh.previousX) / deltaTime : 0;
     mesh.previousX = x;
     // 操舵ヨー + 車体ロール + 加減速のピッチ(ノーズダイブ/スクワット)
@@ -598,6 +626,7 @@ export function syncMeshes(world: World, deltaTime: number): void {
     mesh.pitch +=
       (clamp(acceleration * 0.0075, -0.05, 0.03) - mesh.pitch) * Math.min(1, deltaTime * 6);
     mesh.group.rotation.x = mesh.pitch;
+    for (const copy of mesh.loopGroups) copy.rotation.copy(mesh.group.rotation);
     // ヘッドライトの光だまり: 車体の揺れに追従させず、常に路面上へ平置きする
     mesh.beam.visible = themeState.mix > 0.04;
     const yaw = mesh.group.rotation.y;
@@ -607,6 +636,11 @@ export function syncMeshes(world: World, deltaTime: number): void {
       vehicle.z - Math.cos(yaw) * mesh.beamDistance,
     );
     mesh.beam.rotation.y = yaw;
+    mesh.loopBeams.forEach((beam, index) => {
+      beam.position.set(mesh.beam.position.x, mesh.beam.position.y, copyZs[index]);
+      beam.rotation.copy(mesh.beam.rotation);
+      beam.visible = mesh.beam.visible;
+    });
     mesh.brakeMaterial.color.setHex(vehicle.braking ? 0xff2a2a : themeState.tailIdleHex);
     mesh.brakeGlow.visible = vehicle.braking;
     if (vehicle.braking) brakeGlowMaterial.opacity = 0.45 + 0.45 * themeState.mix;
@@ -625,7 +659,9 @@ export function syncMeshes(world: World, deltaTime: number): void {
     for (const [vehicle, mesh] of meshMap) {
       if (!alive.has(vehicle)) {
         scene.remove(mesh.group);
+        for (const copy of mesh.loopGroups) scene.remove(copy);
         scene.remove(mesh.beam); // 光だまりはシーン直下にあるため個別に外す
+        for (const beam of mesh.loopBeams) scene.remove(beam);
         // ジオメトリはブループリント共有なので破棄しない(マテリアルのみ個別)
         mesh.brakeMaterial.dispose();
         mesh.blinkLeft.dispose();

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, test } from 'vitest';
 import { CONST, createRng, Vehicle, World } from './src/core';
+import { loopCopies } from './src/render/looping';
 
 /* ---------- ヘルパー: シナリオ実行 ---------- */
 const TIME_STEP = 1 / 20;
@@ -674,5 +675,15 @@ describe('合流(加速車線)の協調 (Issue #33)', () => {
     );
     world.step(TIME_STEP);
     expect(main.yieldSlowTimer, '速度差が大きいのに譲ってしまった').toBe(0);
+  });
+});
+
+/* ============================================================
+   12. 周回道路の描画 (Issue #73)
+   車両が周回境界を越える追尾視点でも、道路設備が前後に続いて見える。
+   ============================================================ */
+describe('周回道路の描画 (Issue #73)', () => {
+  test('境界の前後1周ぶんに同じ道路設備を配置する', () => {
+    expect(loopCopies(0)).toEqual([-816, 0, 816]);
   });
 });


### PR DESCRIPTION
## 概要
追尾・ドライバー視点で車両が周回境界を越える際、道路や車両が途切れて見える問題（Issue #73）を修正しました。

## 原因
車両は `WRAP_LENGTH`（816m）で周回する一方、道路・路側設備・車両表示は実体の座標1周分しかなく、境界に道路端や車両のワープが露出していました。

## 変更内容
- `WRAP_LENGTH` を基準に道路、車線、中央仕切り、路側防護柵を前後1周ぶん複製
- 各車両のメッシュとヘッドライト照射を前後1周ぶん表示専用コピーとして複製
- コピーは `World`、物理計算、追尾対象には登録せず、実体の姿勢・灯火状態だけを同期
- `main` の変更を取り込み、コンフリクトを解消
- L/R の交通挙動と比較条件は変更なし

## 検証
- `pnpm check`
- `pnpm build`
- `pnpm test`（54 tests passed）

## 関連 Issue
Closes #73