### PR TITLE
渋滞を表すアプリアイコンと favicon を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,7 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title>6車線比較 渋滞シミュレーション</title>
-    <link
-      rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚗</text></svg>"
-    />
+    <link rel="icon" type="image/svg+xml" href="/traffic-jam.svg" />
   </head>
   <body>
     <div id="container"></div>
@@ -29,7 +26,7 @@
     <!-- コントロールパネル（左上） -->
     <div id="controlPanel" class="sign panel">
       <div class="panel-title">
-        <span class="route-badge">E6</span>渋滞シミュレーション<span class="chev"
+        <img class="app-icon" src="/traffic-jam.svg" alt="" />渋滞シミュレーション<span class="chev"
           ><i data-lucide="chevron-down"></i
         ></span>
       </div>

--- a/public/traffic-jam.svg
+++ b/public/traffic-jam.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#05613b" />
+  <path d="M18 8v48M32 8v48M46 8v48" fill="none" stroke="#d9f3e5" stroke-width="3" stroke-linecap="round" stroke-dasharray="7 5" opacity=".9" />
+  <g fill="#fff" stroke="#173d2a" stroke-width="2" stroke-linejoin="round">
+    <path d="M11 17h12l3 5v8H8v-8z" />
+    <path d="M27 28h12l3 5v8H24v-8z" />
+    <path d="M43 39h12l3 5v8H40v-8z" />
+  </g>
+  <g fill="#173d2a">
+    <circle cx="13" cy="30" r="2.5" />
+    <circle cx="23" cy="30" r="2.5" />
+    <circle cx="29" cy="41" r="2.5" />
+    <circle cx="39" cy="41" r="2.5" />
+    <circle cx="45" cy="52" r="2.5" />
+    <circle cx="55" cy="52" r="2.5" />
+  </g>
+</svg>

--- a/src/style.css
+++ b/src/style.css
@@ -180,6 +180,11 @@ canvas {
   border: 2px solid #05613b;
   box-shadow: 0 0 0 2px #fff;
 }
+.app-icon {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+}
 .row {
   font-size: 12.5px;
   margin: 7px 0;


### PR DESCRIPTION
## 概要

Issue #46 の「E6」の意味不明な表記を、アプリの内容を伝える渋滞アイコンに置き換えました。

- 緑の道路標識風の背景に、3レーンと詰まった車列を描いた repo-native SVG を追加
- 左上パネルの `E6` 表記をこのアイコンに変更
- 同じ SVG を favicon として設定

## 採用デザイン

高速道路の案内標識に合わせた深緑をベースに、破線の3車線と前方に連なる白い車両で「渋滞シミュレーション」を表現しています。絵文字や意味を持たない道路番号には依存しません。

## 検証

- `pnpm check` — 成功（フォーマット、lint、型チェック）
- `pnpm test` — 成功（49件）
- `pnpm build` — 成功
- ビルド成果物で favicon／UIアイコン双方の参照と `traffic-jam.svg` の出力を確認

Closes #46