### PR TITLE
俯瞰カメラを端末向きに対応

### DIFF
--- a/src/render/camera-layout.ts
+++ b/src/render/camera-layout.ts
@@ -1,0 +1,9 @@
+/* ================= カメラ構図の端末向き判定 ================= */
+
+/**
+ * 横幅が高さ以上なら、道路の進行方向を横に見せる俯瞰構図を選ぶ。
+ * 正方形も構図の変化を付けるため横向きとして扱う。
+ */
+export function isLandscapeViewport(width: number, height: number): boolean {
+  return width >= height;
+}

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -2,6 +2,7 @@
 import * as THREE from 'three';
 import { CONST, clamp, smooth } from '../core';
 import type { Vehicle, World } from '../core';
+import { isLandscapeViewport } from './camera-layout';
 import { camera, renderer } from './scene';
 
 export interface CameraController {
@@ -111,9 +112,14 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'overhead',
     label: '俯瞰',
     icon: 'map',
-    // 高所からほぼ真上に見下ろす固定俯瞰。両区間の流れを俯瞰で比較できる
+    // 端末の長辺に道路の進行方向を合わせる。横長(正方形を含む)では横から、
+    // 縦長では従来どおり奥側から見下ろし、両区間の流れを比較しやすくする
     compute(pose) {
-      pose.position.set(CENTER_X, 150, 34);
+      if (isLandscapeViewport(innerWidth, innerHeight)) {
+        pose.position.set(CENTER_X + 52, 150, -6);
+      } else {
+        pose.position.set(CENTER_X, 150, 34);
+      }
       pose.target.set(CENTER_X, 0, -6);
     },
   },

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, test } from 'vitest';
 import { CONST, createRng, Vehicle, World } from './src/core';
+import { isLandscapeViewport } from './src/render/camera-layout';
 import { loopCopies } from './src/render/looping';
 
 /* ---------- ヘルパー: シナリオ実行 ---------- */
@@ -789,5 +790,18 @@ describe('リセット時の内部状態初期化 (Issue #54)', () => {
 describe('周回道路の描画 (Issue #73)', () => {
   test('境界の前後1周ぶんに同じ道路設備を配置する', () => {
     expect(loopCopies(0)).toEqual([-816, 0, 816]);
+  });
+});
+
+/* ============================================================
+   13. 俯瞰カメラの端末向き (Issue #76)
+   ============================================================ */
+describe('俯瞰カメラの端末向き (Issue #76)', () => {
+  test.each([
+    [1280, 720, true],
+    [720, 1280, false],
+    [900, 900, true],
+  ])('%ix%i は横向き判定が %s', (width, height, expected) => {
+    expect(isLandscapeViewport(width, height)).toBe(expected);
   });
 });


### PR DESCRIPTION
## 概要

- 横長端末と正方形では、道路の進行方向が画面の横に収まる俯瞰構図へ切り替えます。
- 縦長端末では従来どおり進行方向を縦に見せる構図を維持します。
- #76

## 検証

- `pnpm test`（57 passed）
- `pnpm check`
- `pnpm build`

## 実験的妥当性

カメラ描画と端末向き判定だけを変更しており、L/R の車両ロジック、物理、区間依存条件には変更がありません。

## 補足

worktree 作成時に VS Code を開こうとしましたが、この環境では `code` コマンドが存在しませんでした。