### PR TITLE
fix: 高さのあるオブジェクトに影を落とす (#66)

### DIFF
--- a/src/render/night.ts
+++ b/src/render/night.ts
@@ -125,6 +125,7 @@ const MEDIAN_X = (sectionX('L', -7) + sectionX('R', -7)) / 2; // 2区間の中�
     for (const side of [-1, 1]) {
       headPositions.push([MEDIAN_X + side * 2.6, 7.0, z]);
       // 電球のにじみ(夜のみ): 灯具が光源として「光って見える」ように
+      // 発光表現が影を落とすと不自然なため castShadow は設定しない
       const bulb = new THREE.Sprite(bulbMaterial);
       bulb.scale.set(2.6, 2.6, 1);
       bulb.position.set(MEDIAN_X + side * 2.6, 6.92, z);
@@ -133,13 +134,21 @@ const MEDIAN_X = (sectionX('L', -7) + sectionX('R', -7)) / 2; // 2区間の中�
       glowMatrices.push(glowRotation.clone().setPosition(MEDIAN_X + side * 3.2, 0.03, z));
     }
   }
-  scene.add(instancedAt(poleGeometry, poleMaterial, polePositions));
-  scene.add(instancedAt(armGeometry, poleMaterial, armPositions));
-  scene.add(instancedAt(headGeometry, lampHeadMaterial, headPositions));
+  const poles = instancedAt(poleGeometry, poleMaterial, polePositions);
+  poles.castShadow = true;
+  scene.add(poles);
+  const arms = instancedAt(armGeometry, poleMaterial, armPositions);
+  arms.castShadow = true;
+  scene.add(arms);
+  const heads = instancedAt(headGeometry, lampHeadMaterial, headPositions);
+  heads.castShadow = true;
+  scene.add(heads);
+  // 夜のみ表示する発光表現が影を落とすと不自然なため castShadow は設定しない
   nightGroup.add(instancedWith(glowGeometry, lampGlowMaterial, glowMatrices));
 })();
 
 // 標識ゲートの投光(夜は案内標識が照明で浮かび上がる)
+// 夜のみ表示する発光表現が影を落とすと不自然なため castShadow は設定しない
 {
   const signGlowPositions: [number, number, number][] = [];
   for (const z of GANTRY_Z)

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -58,8 +58,10 @@ function shadowHalfExtent(axis: THREE.Vector3): number {
 const shadowHalfWidth = shadowHalfExtent(shadowAxisX);
 const shadowHalfHeight = shadowHalfExtent(shadowAxisY);
 const shadowHalfDepth = shadowHalfExtent(shadowAxisZ);
-sun.shadow.mapSize.set(4096, 1024);
-// WebGL の MAX_TEXTURE_SIZE 保証値は 2048。上限が低い端末では three が 2048x1024 へ縮める。
+sun.shadow.mapSize.set(4096, 2048);
+// 約841m×189mの範囲で縦約10.8px/mを確保し、太さ0.2mの支柱を約2テクセルで描く。
+// 深度テクスチャは約32MBになるが、静的な設備中心で追加描画は数十 draw call に留まる。
+// WebGL の MAX_TEXTURE_SIZE 保証値は 2048。上限が低い端末では three が 2048x2048 へ縮める。
 sun.shadow.camera.left = -shadowHalfWidth;
 sun.shadow.camera.right = shadowHalfWidth;
 sun.shadow.camera.top = shadowHalfHeight;

--- a/src/render/scenery.ts
+++ b/src/render/scenery.ts
@@ -20,12 +20,15 @@ const ROAD_HALF = CONST.ROAD_HALF;
     for (const offset of loopCopies(0)) {
       const rail = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.3, WRAP_LENGTH), railMaterial);
       rail.position.set(18.2 * side, 0.62, offset);
+      rail.castShadow = true;
       scene.add(rail);
       for (let z = -WRAP_LENGTH / 2 + 4; z < WRAP_LENGTH / 2; z += 12)
         postPositions.push([18.2 * side, 0.4, z + offset]);
     }
   }
-  scene.add(instancedAt(postGeometry, postMaterial, postPositions));
+  const posts = instancedAt(postGeometry, postMaterial, postPositions);
+  posts.castShadow = true;
+  scene.add(posts);
   // 遮音壁: 下段コンクリート + 上段の半透明パネル(高速道路らしさ)
   const wallMaterial = new THREE.MeshLambertMaterial({ color: 0xb4b9bd });
   const panelMaterial = new THREE.MeshLambertMaterial({
@@ -47,10 +50,14 @@ const ROAD_HALF = CONST.ROAD_HALF;
     scene.add(base);
     const panel = new THREE.Mesh(new THREE.BoxGeometry(0.14, 1.7, length), panelMaterial);
     panel.position.set(19.2 * side, 2.35, zCenter);
+    // three r128 では半透明の影は不透明になるが、下段の影が途中で切れる違和感を避ける
+    panel.castShadow = true;
     scene.add(panel);
     for (let z = zStart; z <= zEnd; z += 10) wallPostPositions.push([19.2 * side, 1.6, z]);
   }
-  scene.add(instancedAt(wallPostGeometry, wallPostMaterial, wallPostPositions));
+  const wallPosts = instancedAt(wallPostGeometry, wallPostMaterial, wallPostPositions);
+  wallPosts.castShadow = true;
+  scene.add(wallPosts);
 })();
 
 /* ---- 並木・雑木林(InstancedMeshで軽量に大量配置) ---- */
@@ -69,6 +76,7 @@ const ROAD_HALF = CONST.ROAD_HALF;
     new THREE.MeshLambertMaterial({ color: 0xffffff }),
     treeCount,
   );
+  trunks.castShadow = true;
   canopies.castShadow = true;
   const matrix = new THREE.Matrix4(),
     color = new THREE.Color();
@@ -95,6 +103,7 @@ const ROAD_HALF = CONST.ROAD_HALF;
 })();
 
 /* ---- 遠景: 山並み(霧の外に置く書割り) ---- */
+// 影マップ範囲外の書割りで、影がシーン全体を覆うため castShadow は設定しない
 (function buildMountains() {
   const far = new THREE.Mesh(
     new THREE.CylinderGeometry(860, 860, 180, 72, 1, true),
@@ -114,6 +123,7 @@ const ROAD_HALF = CONST.ROAD_HALF;
 })();
 
 /* ---- 雲 ---- */
+// 霧の外に置く書割りで影マップ範囲外のため castShadow は設定しない
 (function buildClouds() {
   for (let i = 0; i < 9; i++) {
     const theta = Math.random() * Math.PI * 2,

--- a/src/render/track.ts
+++ b/src/render/track.ts
@@ -141,6 +141,7 @@ for (const section of SECTIONS) {
     for (const railX of [-0.3, 0.3]) {
       const rail = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.14, WRAP_LENGTH), railMaterial);
       rail.position.set(railX, 0.95, z);
+      rail.castShadow = true;
       scene.add(rail);
     }
   }
@@ -155,7 +156,10 @@ for (const section of SECTIONS) {
       for (const offsetZ of [-0.09, 0.09])
         delineatorPositions.push([0, 1.12, z + offset + offsetZ]);
     }
-  scene.add(instancedAt(postGeometry, railMaterial, postPositions));
+  const posts = instancedAt(postGeometry, railMaterial, postPositions);
+  posts.castShadow = true;
+  scene.add(posts);
+  // 1テクセル未満で影を視認できない極小装飾のため castShadow は設定しない
   scene.add(instancedAt(delineatorGeometry, delineatorMaterial, delineatorPositions));
 })();
 
@@ -264,6 +268,8 @@ function buildGantry(section: Section, z: number): void {
     const board = new THREE.Mesh(boardGeometry, boardMaterial);
     board.position.set(centerX, 8.3, z + dir * 0.06);
     if (dir === -1) board.rotation.y = Math.PI;
+    // 表裏の影はほぼ完全に重なるため、片面だけ描画してシャドウパスを抑える
+    if (dir === 1) board.castShadow = true;
     group.add(board);
   }
   scene.add(group);


### PR DESCRIPTION
## 背景

Issue #66 のとおり、高さがあるのに影が出ていないオブジェクトが残っていた。`castShadow` の設定状況を `src/render/` 全体で棚卸しし、抜けを埋めた。

加えて、`castShadow` を付けただけでは街灯の支柱の影が出ないことが分かった。平行光源のシャドウマップは 4096x1024 で、影の範囲（シャドウカメラのローカル軸に沿って約 841m x 189m）に対して縦約 5.4px/m しかない。太さ 0.2m の支柱は影の幅が 1 テクセル未満になり、PCFSoftShadowMap のフィルタでほぼ消えてしまう。これが「街灯に影がない」ように見える直接の原因だった。

## 影がなかったオブジェクトと対応

### 影を落とすようにしたもの

| オブジェクト | ファイル | 備考 |
| --- | --- | --- |
| 街灯の支柱（高さ 7.2m） | `src/render/night.ts` | InstancedMesh 自体に設定 |
| 街灯のアーム（幅 5.4m） | `src/render/night.ts` | 同上 |
| 街灯の灯具ヘッド | `src/render/night.ts` | 同上 |
| 路側の防護柵レール | `src/render/scenery.ts` | |
| 路側の防護柵の支柱（高さ 0.8m） | `src/render/scenery.ts` | InstancedMesh |
| 遮音壁の半透明パネル（高さ 1.7m） | `src/render/scenery.ts` | 下段コンクリートは元から影あり |
| 遮音壁の支柱（高さ 3.2m） | `src/render/scenery.ts` | InstancedMesh |
| 並木の幹 | `src/render/scenery.ts` | 樹冠は元から影あり |
| 区間の仕切りのガードレール | `src/render/track.ts` | |
| 仕切りの支柱（高さ 0.55m） | `src/render/track.ts` | InstancedMesh |
| 頭上標識ゲートの標識ボード（10.5 x 3.3m） | `src/render/track.ts` | 表裏 2 枚のうち片面のみ |

InstancedMesh はインスタンス単位ではなくメッシュ自体に `castShadow` を設定する必要があるため、`instancedAt()` の戻り値をローカル変数で受けてから設定している。

### 意図的に対象外にしたもの（理由はコード内コメントに記載）

- **電球のにじみ / 路面の光だまり / 標識ゲートの投光**（`night.ts`）: 夜のみ表示する発光表現。光源側が影を落とすのは不自然。
- **遠景の山並み・雲**（`scenery.ts`）: 霧の外に置く書割り。影マップ範囲外で、影を落とすとシーン全体を覆ってしまう。
- **視線誘導標（デリネーター、0.16 x 0.16 x 0.06m）**（`track.ts`）: 1 テクセル未満で影が視認できない極小装飾。
- **白線・破線・路肩ライン・導流帯・路面ペイント文字**: 路面に貼り付いた高さ 0 の平面。
- **標識ボードの裏面**: 表裏 2 枚は z 方向に 0.12m しか離れておらず影がほぼ完全に重複するため、片面だけを影の対象にしてシャドウパスの描画回数を半分に抑えた。
- **車両の小部品（トリム / ホイールハブ / ナンバープレート / 灯火類）**: 車体・ガラス・タイヤ・荷台は元から影を落としており、小部品の影は車体の影の輪郭に埋まる。車両台数分だけシャドウ描画が増えるコストに見合わないため `vehicle-mesh.ts` は変更していない。

なお、半透明の遮音壁パネルは three r128 では半透明の影を表現できず不透明な影になるが、下段コンクリートの影が途中で切れて見えるほうが違和感が大きいと判断して影を落としている。

## シャドウカメラ範囲の調整

- **`sun.shadow.mapSize`: 4096 x 1024 → 4096 x 2048**（縦のテクセル密度が約 5.4px/m → 約 10.8px/m。太さ 0.2m の支柱の影が約 2 テクセル幅になり視認できるようになる）
- **範囲（`shadowBoundsHalfSize` / `shadow.camera` の left/right/top/bottom/near/far）は変更なし**。既存の範囲（x ±100m, y ±14m, z ±424m）で街灯（高さ 7.2m）・標識ゲート（高さ 8.3m）・並木（x = ±92m まで）をすべて覆えており、範囲を狭めると遠い並木の影が欠けて別の不具合になる。
- **`bias` / `normalBias` も変更なし**。解像度を上げる方向の変更なのでシャドウアクネは悪化しない。

## パフォーマンスへの配慮

- 影の対象は静的な道路設備が中心で、繰り返し配置はすべて InstancedMesh のまま（支柱類は 1 メッシュ = 1 draw call）。シャドウパスに増える描画は数十 draw call 程度。
- 標識ボードの裏面を除外して、ガントリー由来のシャドウ描画を 16 回 → 8 回に半減。
- 破線・デリネーターなど影が視認できないものは対象外にして無駄なシャドウ描画を作らない。
- 深度テクスチャは 4096 x 2048 で約 32MB に増える。WebGL の `MAX_TEXTURE_SIZE` 保証値は 2048 なので、上限が低い端末では three が 2048 x 2048 に縮める（従来も 4096 側は縮められていた）。

## 実験的妥当性（AGENTS.md A 章）

描画のみの変更で `src/core/**` と `traffic-simulation.test.ts` は一切触っていない。影の設定は L/R 完全同一で、`section` による分岐は入れていない。`src/render/track.ts` の変更は影の設定行のみに絞っており、ジオメトリ・レイアウトは変更していない。

## 検証

- `pnpm check`: pass（39 ファイルのフォーマット / 31 ファイルの lint・型チェックで警告・エラーなし）
- `pnpm test`: 158 passed（L/R スコア差の回帰ガードを含めて全通過）
- `pnpm build`: 成功（既存のチャンクサイズ警告のみ）

ブラウザでの視覚確認は未実施のため、実機での影の見え方（特に細い支柱の影の濃さ、半透明パネルの不透明な影の印象）はレビューで確認いただきたい。

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
