### PR TITLE
fix: checkLaneSafetyForChange が周回(ラップ)を考慮していない問題を修正 (#50)

### DIFF
--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -1129,11 +1129,13 @@ export class Vehicle {
     const vehicles = this.world.sectionVehicles[this.section];
     for (const other of vehicles) {
       if (other === this || !other.occupies(toLane)) continue;
-      const deltaZ = Math.abs(other.z - this.z);
-      if (deltaZ > 90) continue;
-      if (other.z <= this.z) {
+      // 周回路なので符号付き最短距離で前後を判定する(継ぎ目をまたぐ相手も拾う)。
+      // deltaZ <= 0 なら相手は前方(z が小さい側)、> 0 なら後方。
+      const deltaZ = wrapDelta(other.z - this.z);
+      if (Math.abs(deltaZ) > 90) continue;
+      if (deltaZ <= 0) {
         // 変更先の前方車
-        const gap = this.z - other.z - (this.length + other.length) / 2;
+        const gap = -deltaZ - (this.length + other.length) / 2;
         if (gap < 1.5) return 'danger';
         const requiredGap = (4 + this.speed * 0.45) * relax;
         if (gap < requiredGap) {
@@ -1143,7 +1145,7 @@ export class Vehicle {
         }
       } else {
         // 変更先の後方車
-        const gap = other.z - this.z - (this.length + other.length) / 2;
+        const gap = deltaZ - (this.length + other.length) / 2;
         if (gap < 1.5) return 'danger';
         const relativeSpeed = other.speed - this.speed;
         const requiredGap = (4 + Math.max(0, relativeSpeed) * 2.2 + other.speed * 0.22) * relax;

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -27,6 +27,7 @@ import {
   Vehicle,
   World,
   WRAP_LENGTH,
+  wrapDelta,
 } from './src/core';
 import { isLandscapeViewport } from './src/render/camera-layout';
 import { flybyPose } from './src/render/flyby';
@@ -3317,5 +3318,96 @@ describe('車両数上限の区間独立性 (Issue #72)', () => {
       CONST.MAX_VEHICLES,
       `総上限 ${CONST.MAX_VEHICLES}台 !== 片側上限 ${CONST.MAX_VEHICLES_PER_SECTION}台の2倍`,
     ).toBe(CONST.MAX_VEHICLES_PER_SECTION * 2);
+  });
+});
+
+/* ============================================================
+   車線変更安全確認の周回考慮 (Issue #50)
+   checkLaneSafetyForChange だけが素の z 比較で前後関係と距離を判定しており、
+   道路の継ぎ目 (z = ±ROAD_HALF 付近) をまたぐ相手を見落としていた。
+   同ファイルの他の探索関数 (findAlongside など) と揃えて wrapDelta による
+   周回路上の符号付き最短距離で判定する。区間非依存の修正である。
+   ============================================================ */
+describe('車線変更安全確認の周回考慮 (Issue #50)', () => {
+  // 継ぎ目をまたいで真横に並ぶ 2 台。素の z 差は 806m だがリング上は 10m しかない。
+  function setupSeamPair(section: 'L' | 'R') {
+    const world = new World({ rng: createRng(50), spawnInterval: 1e9 });
+    const mover = new Vehicle(world, section, 0, -405, 'Sedan', 25);
+    mover.speed = 25;
+    const blocker = new Vehicle(world, section, 1, 401, 'Sedan', 25);
+    blocker.speed = 25;
+    world.vehicles.push(mover, blocker);
+    world.rebuildSectionIndex();
+    return { world, mover, blocker };
+  }
+
+  test('継ぎ目をまたいだ真横の車を検知して車線変更を許可しない', () => {
+    const { mover, blocker } = setupSeamPair('L');
+    // 前提: 素の z 差は 806m、リング上の最短距離は 10m
+    expect(Math.abs(blocker.z - mover.z)).toBeCloseTo(806, 5);
+    expect(Math.abs(wrapDelta(blocker.z - mover.z))).toBeCloseTo(10, 5);
+    // findAlongside は正しく真横と認識している
+    expect(mover.findAlongside(1), 'findAlongside が継ぎ目越しの並走車を見落とした').toBe(blocker);
+    // checkLaneSafetyForChange も同じ相手を危険と判定しなければならない
+    expect(mover.checkLaneSafetyForChange(1), '継ぎ目をまたぐ並走車を無視して safe を返した').toBe(
+      'danger',
+    );
+  });
+
+  test('継ぎ目をまたぐ状況では車線変更が成立しない', () => {
+    const { mover } = setupSeamPair('L');
+    expect(mover.tryLaneChange(1), '危険なのに車線変更が成立した').toBe(false);
+    expect(mover.laneChange.state).toBe('none');
+  });
+
+  test('継ぎ目をまたぐ後方車も同様に検知する', () => {
+    // 相手を後方 (z が大きい側) に置いたケース。
+    const world = new World({ rng: createRng(50), spawnInterval: 1e9 });
+    const mover = new Vehicle(world, 'L', 0, 401, 'Sedan', 25);
+    mover.speed = 25;
+    const chaser = new Vehicle(world, 'L', 1, -405, 'SportsCar', 34);
+    chaser.speed = 34;
+    world.vehicles.push(mover, chaser);
+    world.rebuildSectionIndex();
+    // -405 はリング上では 401 の 10m 後方
+    expect(wrapDelta(chaser.z - mover.z)).toBeCloseTo(10, 5);
+    expect(
+      mover.checkLaneSafetyForChange(1),
+      '継ぎ目をまたぐ高速の後続車を無視して safe を返した',
+    ).toBe('danger');
+  });
+
+  test('リング全体を平行移動しても安全判定は変わらない (継ぎ目に特異点がない)', () => {
+    // 同一の相対配置をリング上の様々な絶対位置へ回して判定を比較する。
+    // 周回を正しく扱えていれば、判定は配置場所に依らず一定になる。
+    const wrapZ = (z: number) => {
+      const span = CONST.ROAD_HALF + 8;
+      return ((((z + span) % WRAP_LENGTH) + WRAP_LENGTH) % WRAP_LENGTH) - span;
+    };
+    function verdictAtOffset(offset: number): 'safe' | 'hold' | 'danger' {
+      const world = new World({ rng: createRng(50), spawnInterval: 1e9 });
+      const mover = new Vehicle(world, 'L', 0, wrapZ(offset), 'Sedan', 25);
+      mover.speed = 25;
+      const blocker = new Vehicle(world, 'L', 1, wrapZ(offset + 10), 'Sedan', 25);
+      blocker.speed = 25;
+      world.vehicles.push(mover, blocker);
+      world.rebuildSectionIndex();
+      return mover.checkLaneSafetyForChange(1);
+    }
+
+    const baseline = verdictAtOffset(0);
+    expect(baseline).toBe('danger');
+    for (let offset = 0; offset < WRAP_LENGTH; offset += 17) {
+      expect(
+        verdictAtOffset(offset),
+        `オフセット ${offset}m で判定が ${baseline} から変化した = 継ぎ目で挙動が変わっている`,
+      ).toBe(baseline);
+    }
+  });
+
+  test('L/R で判定が一致する (区間依存の分岐が入っていない)', () => {
+    const left = setupSeamPair('L');
+    const right = setupSeamPair('R');
+    expect(right.mover.checkLaneSafetyForChange(1)).toBe(left.mover.checkLaneSafetyForChange(1));
   });
 });


### PR DESCRIPTION
Closes #50

> [!WARNING]
> **Draft で出しています。** 修正自体は正しく、かつ**実在する貫通を 1 件直している**ことを確認しました（後述）。ただしその結果として渋滞スコア差の回帰ガードが下限を割ります（平均差 8.68 → 3.68、下限 7）。AGENTS.md A 節により、区間依存の条件追加や閾値の緩和で数値を回復させる行為は禁止されているため、**辻褄合わせは一切していません。** 再較正の方針は #52 の実測待ちです。判断を人間にお願いします。

## 変更内容

`checkLaneSafetyForChange` だけが素の z 比較で前後関係と距離を判定しており、道路の継ぎ目（z = ±408 付近）をまたいで隣接する車両を「90m 以上離れている」と誤認して無視していました。

```ts
// 修正前
const deltaZ = Math.abs(other.z - this.z);
if (deltaZ > 90) continue;
if (other.z <= this.z) {

// 修正後
const deltaZ = wrapDelta(other.z - this.z);
if (Math.abs(deltaZ) > 90) continue;
if (deltaZ <= 0) {
```

同ファイルの他の探索関数（`hasDeadlockAlongside` / `findAlongside` / `findMergingVehicle` / `findAhead` / `findBehind`）および `world.ts` の `isSpawnClear` / `aheadInfo` はすべて `wrapDelta` / `WRAP_LENGTH` で周回を扱っており、この関数だけが例外でした。Issue の指摘どおり設計判断ではなく漏れです。

**判定は L/R 完全同一で、`section` / `yields` / `camper` / `keepLeft` / `returnTime` は一切参照していません。**

### 変更が厳密に加算的であることの確認

`WRAP_LENGTH = 816` なので、素の z 差 `d` が `|d| < 408` の範囲では `wrapDelta(d) === d` です。したがって、

- `|d| <= 90`: 修正前後で完全に同一の判定
- `90 < |d| < 408`: 修正前後ともスキップ
- `|d| > 408`: **修正前のみスキップ**（= 継ぎ目をまたぐ組だけが新たに考慮される）

挙動が変わるのは継ぎ目をまたぐ組のみで、それ以外の判定には一切影響しません。

## 実在する貫通を 1 件直していることの検証

Issue #53 本文には「実際には貫通していない（重なり 0 件）」とありますが、**これは誤りです。** 従来の貫通チェックは区間全体を z 昇順に並べた配列の**隣接 index のみ**を見ており、継ぎ目をまたぐペア（配列の先頭と末尾）を構造的に検査できていなかったため、見逃していました。

全ペア・周回対応の検査を書き直して、main と本 PR を**同一シード・同一条件**で比較しました。

| | 検査ペア数 | 重なり件数 | 最小車間 |
| --- | --- | --- | --- |
| main (`347df75`) | 774,915 | **1** | **-1.573 m** |
| 本 PR (`58cfb03`) | 771,906 | **0** | **+1.423 m** |

条件: シード `[11,22,33,44,55,66,77,88,99,110]` × 300 秒、`spawnInterval=800`、0.5 秒ごとに全車線・全ペアを検査。

**計測の妥当性のために潰した点:**

- **`occupies()` による隣車線占有を重なりと誤判定しない。** `occupies()` は車線変更中に `from` / `to` の両車線について true を返すため、これをそのまま使うと「またいでいる車」と「隣車線の正常な車」が重なっていると誤検出されます。車線変更中の車は検査から除外しました（保守的側に倒しており、偽陽性は出ません）。
- **入口待ち（`waiting`）車の扱い。** エンジン自身が `isSpawnClear` / `aheadInfo` で `waiting` を除外しているため、除外した場合と含めた場合の両方で計測しました。**本件では結果は完全に同一**（上表の数値は両方で一致）でした。
- **加速車線（lane 3）は環状ではない**ので、周回を閉じるペア（末尾↔先頭）は作っていません。

### 検出された重なりの因果（main, seed=33）

| 時刻 | 出来事 |
| --- | --- |
| t=55.05〜55.60 | R区間 lane1 の **#67** が急減速しながら継ぎ目へ接近（v: 8.12 → 2.42） |
| t=55.65 | #67 が継ぎ目を通過し `z = -408.00 → +407.96` へワープ。直後に **v=0 で停止** |
| **t=55.85** | lane2 の **#105**（`z=-400.49`, `v=19.56`）が **lane2 → lane1 へ車線変更成立** |
| t=57.55 | #67 (`z=+406.59`) と #105 (`z=-406.38`) が **1.573 m 重なる** |

t=55.85 の車線変更の瞬間の判定を両ロジックで並べると:

```
#105 の lane2 -> lane1 車線変更
  相手 = #67 (z = +408.0)
  素の z 差   = 808.4 m  -> 「90m 超」としてスキップ -> 'safe'   ... main はこれで許可した
  wrapDelta   =  -7.6 m  -> #67 はリング上 7.6m 前方
                            車間 2.95 m / 要求車間 12.80 m -> 'danger' ... 本 PR は拒否する
```

**停止している車の 7.6m 手前へ 19.5 m/s で車線変更している**わけで、1.7 秒後に重なるのは当然です。本 PR の修正はこの車線変更を `danger` として正しく拒否し、10 シード全体で重なりが 0 件になります。

> [!NOTE]
> 検査は 0.5 秒ごとのサンプリングなので、0.5 秒未満で解消する重なりは取りこぼしている可能性があります。「main の重なりはちょうど 1 件」ではなく「**サンプリングで確実に 1 件は実在した**」と読んでください。0 件でないことが要点です。

## 落ちている既存テスト 3 件の判定

`pnpm test`: **3 件 fail / 163 件 pass（166 件中）**。追加した 5 件はすべて pass です。

### 1. 加速復帰（義務なし区間）→ **バグ依存で通っていた**（証拠あり）

> `加速復帰（追いつかれ時に並走車を抜いて戻る） > 義務なし区間: 並走車との速度差が小さく前方が空いていれば、加速して前に出て復帰する`

**主張していること:** 追い越し車線の `overtaker` が後続に追いつかれ、復帰先レーン1 が同速の `side` に塞がれているとき、加速して前に出て **25 秒以内に**レーン1 へ復帰できること。

**判定:** バグ依存です。トレースで確認しました。

main での R区間の復帰は **t=16.05s** に起きますが、その瞬間の配置は:

```
overtaker: z = -394.0  (v=24.0, lane0)
side:      z = +405.8  (v=25.8, lane1)
素の z 差 = 799.9 m -> 「90m 超」としてスキップ -> 'safe'       ... 復帰が成立した
wrapDelta = -16.1 m -> side はリング上 16.1m 前方
                       車間 11.54 m / 要求車間 11.86 m
                       かつ side の方が速い(25.8 >= 24.0+1) -> 'hold'
```

つまり **`overtaker` が継ぎ目を越えた瞬間に `side` を検査対象から丸ごと外したこと**だけで `safe` が出ており、この 1 ステップが assertion `returned === true` を満たしていました。L区間は t=13.70s に**継ぎ目の手前で**復帰しているため、修正前後で挙動が変わらず pass のままです（落ちるのは R のみ）。

**ただし重要な補足:** 修正後、R区間の `overtaker` は **t=25.30s に復帰します**。テストの窓が 25.00s なので、**0.30 秒足りずに落ちている**だけです。「復帰できなくなった」のではなく「正しく `hold` した分だけ復帰が 0.3 秒遅れた」が正確な記述です。

**前任者の記述の訂正:** 「808m 離れていると誤認して真横へ車線変更」という説明は、方向性は正しいものの数値と幾何が違いました。実際は 799.9m で、`side` は真横ではなく**リング上 16.1m 前方**です（`808m` という数字は偶然、上の貫通事象の 808.4m と一致します）。

### 2 / 3. スコア差の平均・台数差 → **「バグ依存のテスト」ではなく「バグに水増しされていた較正値」**

> `渋滞スコア差（義務あり vs 義務なし） > 10シード平均のスコア差が 7〜12 に収まる`（実測 3.68、下限 7）
> `流入・流出と滞留 (Issue #12) > 混雑側(義務なし)に車両が滞留し、平均台数が多くなる`（実測 0.11 台、下限 1）

まずこの 2 件は**独立した 2 つの失敗ではありません。** どちらも同じ `getResults()`（10 シード × 300 秒）の集計から出ており、「L/R のコントラストが縮んだ」という**1 つの現象を 2 通りに測っているだけ**です。

**判定:** どちらも特定の挙動を主張するテストではなく、創発統計量の**大きさ**を守る較正ガードです。以下の実測から、その大きさが周回バグに部分的に依存していたと判断します。ただし「不正な挙動が assertion を満たしていた」という 1 番と同じ意味での "バグ依存" ではありません。

**証拠 — バグに依存した車線変更の割合が R 側で 1.53 倍高い:**

main で成立した本線車線変更を全数記録し、それぞれについて「`wrapDelta` 版の判定なら成立したか」を照合しました。

| 区間 | 本線車線変更 総数 | うち wrapDelta 版なら**不成立** | 割合 |
| --- | --- | --- | --- |
| L（義務あり） | 5,472 | 473 | **8.64 %** |
| R（義務なし） | 4,112 | 543 | **13.21 %** |

R 側のほうが継ぎ目の誤判定に依存した車線変更の比率が高く（1.53 倍）、そのぶん修正の効き方が非対称になります。**これは区間依存の分岐によるものではなく**（本 PR は区間変数を一切参照しません）、R のほうが混雑していて継ぎ目付近の車線変更が多いという**交通状況から出る創発的な非対称**です。

**修正後はこの種の車線変更が L/R とも 0 件になります**（同じ照合を修正後コードに当てて確認済み。これは同時に、照合に使った `wrapDelta` 版の再実装が出荷コードと完全一致していることの検証にもなっています）。

**現象そのものは生き残っています:**

- 10 シード**すべてで R > L** のまま（個別シードのテストは 10 件とも pass）。
- 逆転も暴走もなし。壊れたのは平均値の**下限**ガードだけです。

したがって「正当な理由で pass していたテストを修正が壊した」でもありません。**真の較正値が 8.68 ではなく 3.68 だった**、という読み方が実測に一番忠実です。その扱いは再較正の判断（#52 待ち）に属します。

## 実測値の表（10 シード × 300 秒、同一シード）

| | 平均スコア L | 平均スコア R | **平均スコア差** | 平均台数 L | 平均台数 R | **平均台数差** |
| --- | --- | --- | --- | --- | --- | --- |
| main (`347df75`) | 29.557 | 38.232 | **8.675** | 65.886 | 68.874 | **2.988** |
| 本 PR (`58cfb03`) | 26.492 | 30.175 | **3.682** | 66.166 | 66.273 | **0.107** |

| | 本線車線変更 L | 本線車線変更 R |
| --- | --- | --- |
| main | 5,472 | 4,112 |
| 本 PR | 4,916 (**-10.2 %**) | 2,955 (**-28.1 %**) |

（`world.stats.changes` は合流ランプからの車線変更も含むため、上表の本線のみの値より各 30〜45 件多く出ます。）

R の減少幅 28.1 % が「直接ブロックされる 13.21 %」より大きいのは二次効果です。誤判定由来の車線変更が消える → 流れが良くなる → そもそも車線変更の必要が減る、という連鎖が働いています。

### シード別のスコア差

| seed | main | 本 PR |
| --- | --- | --- |
| 11 | 6.35 | 6.24 |
| 22 | 6.30 | 3.43 |
| 33 | 13.08 | 0.26 |
| 44 | 5.17 | 5.49 |
| 55 | 4.08 | 0.75 |
| 66 | 14.57 | 1.34 |
| 77 | 0.91 | 10.98 |
| 88 | 13.12 | 1.29 |
| 99 | 13.01 | 0.63 |
| 110 | 10.17 | 6.42 |

## 追加したテスト

`traffic-simulation.test.ts` 末尾に `車線変更安全確認の周回考慮 (Issue #50)` を新規 describe として追加しました（既存 describe は変更なし）。**5 ケースすべて green** です。

- Issue 記載の再現ケース（`mover.z = -405` / `blocker.z = 401`、リング上 10m）を `danger` と判定する
- 同状況で `tryLaneChange` が成立しない
- 継ぎ目をまたぐ後方車も検知する
- リング全体を平行移動しても判定が変わらない（継ぎ目に特異点がない）
- L/R で判定が一致する

## 未解決の判断事項

> [!IMPORTANT]
> **再較正の方針は #52 の実測待ちです。** 本 PR では較正パラメータ（`checkLaneSafetyForChange` の `requiredGap` 係数など）を一切触っていません。回帰ガードの期待値（`DIFF_AVERAGE_MIN = 7` / `DIFF_AVERAGE_MAX = 12`）も書き換えていません。3 件は落ちたままです。

判断が必要なのは次の点です。

1. **バグ修正を受け入れたうえで、区間非依存にモデルを再較正するか。** 車線変更の要求車間は、周回を見落とす検知器を前提に調整されていた可能性があります。#52（`section` インデックスの陳腐化）の実測が出たあと、両方の効果を合わせて較正をやり直すのが筋だと考えます。
2. **加速復帰テストの 25 秒という窓をどう扱うか。** 修正後の復帰は 25.30s で、窓を 0.3 秒超えているだけです。これは較正ではなくテスト側の窓の妥当性の問題として切り分けられる可能性があります（本 PR では触っていません）。
3. **Issue #53 の本文の訂正。** 「実際には貫通していない（重なり 0 件）」は誤りで、旧チェックが継ぎ目のペアを見られなかっただけでした。本 PR は検出力の話ではなく**実在する貫通**を直しています。（Issue の編集は行っていません。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBRGuQ4Doy7RW3UFLPc9ae
