### PR TITLE
InstancedMeshの視錐台カリング無効化をヘルパー側へ集約する (#89)

### DIFF
--- a/src/render/instancing.ts
+++ b/src/render/instancing.ts
@@ -6,6 +6,20 @@ import * as THREE from 'three';
 
 const _matrix = new THREE.Matrix4();
 
+/** ここで作るInstancedMeshは視錐台カリングを必ず切る (Issue #89)。
+    three の視錐台カリングは `geometry.boundingSphere` を `matrixWorld` で変換した球だけで
+    判定し、各インスタンスの行列を見ない。これらのヘルパーが返すメッシュは matrix が
+    単位行列のままなので、判定球は「原点にあるジオメトリ1個ぶん」の小さな球にしかならない。
+    実体は loopCopies() により z 方向へ周回3本ぶん広がっているため、カリングが効くと
+    原点付近が画面外に出ただけで破線や支柱が丸ごと消える。判定そのものが誤りなので切る。
+    r128 の InstancedMesh はコンストラクタで frustumCulled=false にしており既定でも切れて
+    いるが、three の更新でこの既定が変わると上記の誤判定が復活するため明示しておく。
+    draw call は元々1個にまとめてあり、切っても増えるコストは小さい。 */
+function withoutFrustumCulling(mesh: THREE.InstancedMesh): THREE.InstancedMesh {
+  mesh.frustumCulled = false;
+  return mesh;
+}
+
 /** 平行移動のみの静的な繰り返し配置を1つのInstancedMeshにまとめる */
 export function instancedAt(
   geometry: THREE.BufferGeometry,
@@ -18,7 +32,7 @@ export function instancedAt(
     mesh.setMatrixAt(i, _matrix);
   });
   mesh.matrixAutoUpdate = false;
-  return mesh;
+  return withoutFrustumCulling(mesh);
 }
 
 /** 任意の変換行列で配置する版(回転・スケールが必要な場合) */
@@ -30,5 +44,5 @@ export function instancedWith(
   const mesh = new THREE.InstancedMesh(geometry, material, matrices.length);
   matrices.forEach((matrix, i) => mesh.setMatrixAt(i, matrix));
   mesh.matrixAutoUpdate = false;
-  return mesh;
+  return withoutFrustumCulling(mesh);
 }

--- a/src/render/scenery.ts
+++ b/src/render/scenery.ts
@@ -78,6 +78,9 @@ const ROAD_HALF = CONST.ROAD_HALF;
   );
   trunks.castShadow = true;
   canopies.castShadow = true;
+  // 道路全長に散らすためヘルパー(instancing.ts)と同じ理由で視錐台カリングを切る (Issue #89)
+  trunks.frustumCulled = false;
+  canopies.frustumCulled = false;
   const matrix = new THREE.Matrix4(),
     color = new THREE.Color();
   for (let i = 0; i < treeCount; i++) {

--- a/src/render/track.ts
+++ b/src/render/track.ts
@@ -73,8 +73,6 @@ for (const section of SECTIONS) {
     roadMaterial,
     loopCopies(0).map((z): [number, number, number] => [sectionX(section, -7), -0.06, z]),
   );
-  // 周回前後の複製をまとめているが、r128のカリングはインスタンス行列を見ず原点基準の球で判定するため、全周に及ぶ実体が丸ごと消えないよう無効化する。
-  road.frustumCulled = false;
   road.receiveShadow = true;
   scene.add(road);
 
@@ -89,7 +87,6 @@ for (const section of SECTIONS) {
     frontageRoadMaterial,
     loopCopies(0).map((z): [number, number, number] => [sectionX(section, -15), -0.055, z]),
   );
-  frontageRoad.frustumCulled = false;
   frontageRoad.receiveShadow = true;
   scene.add(frontageRoad);
 }
@@ -112,7 +109,6 @@ function solidLines(
     whiteLineMaterial,
     positions,
   );
-  lines.frustumCulled = false;
   scene.add(lines);
 }
 // 車線境界の破線は全車線ぶんを1つのInstancedMeshに(draw call削減)
@@ -164,7 +160,6 @@ dashedLines(SECTIONS.flatMap((section) => [-5, -9].map((x) => sectionX(section, 
         stripMaterial,
         positions,
       );
-      strip.frustumCulled = false;
       scene.add(strip);
     }
 
@@ -184,7 +179,6 @@ dashedLines(SECTIONS.flatMap((section) => [-5, -9].map((x) => sectionX(section, 
       }
     }
     const tapers = instancedWith(taperGeometry, stripMaterial, taperMatrices);
-    tapers.frustumCulled = false;
     scene.add(tapers);
 
     // 周回境界を展開してから戻すことで、境界をまたいでも正確な9m間隔を保つ。
@@ -205,7 +199,6 @@ dashedLines(SECTIONS.flatMap((section) => [-5, -9].map((x) => sectionX(section, 
   }
 
   const poles = instancedAt(poleGeometry, poleMaterial, polePositions);
-  poles.frustumCulled = false;
   scene.add(poles);
 })();
 


### PR DESCRIPTION
Closes #89

## 調査結果: 症状は現行の three r128 では発生しない

Issue が指摘するカリングの仕組み自体は正しいのですが、**three r128 の `InstancedMesh` は
コンストラクタで `frustumCulled = false` を設定している**ため、そもそもカリング対象になりません。

```js
// node_modules/three/build/three.module.js (r128) の InstancedMesh
class InstancedMesh extends Mesh {
  constructor( geometry, material, count ) {
    super( geometry, material );
    ...
    this.frustumCulled = false;   // ← 既定でカリングされない
  }
```

したがって「破線・導流帯・支柱が丸ごと消える」症状は、現状の実装では**再現しません**。
実機(ヘッドレス Chromium + Playwright)で計測した結果は下記の「検証」の通りです。

ただし Issue が指摘した誤判定の仕組みは実在し、`frustumCulled` を有効にした瞬間に顕在化します。
そこで**描画結果は変えないまま、意図の明示と three 更新に対する保険**として整理しました。

## 変更内容

- `src/render/instancing.ts`: `instancedAt()` / `instancedWith()` が返す `InstancedMesh` で
  一律に `frustumCulled = false` を設定するようにし、なぜ切るのかを日本語コメントで説明。
- `src/render/track.ts`: #86 で呼び出し側に個別に入れていた `frustumCulled = false` 6 箇所を削除
  (ヘルパー側に集約したため重複)。
- `src/render/scenery.ts`: ヘルパーを経由せず直接 `InstancedMesh` を作っている並木(幹・樹冠)にも
  同じ設定を追加。道路全長に散らすため同じ誤判定の対象になる。
- `src/render/night.ts`: 街灯はすべてヘルパー経由なので変更なし(#87 と競合させないため)。

## 検証

`pnpm dev` を起動し、Playwright + ヘッドレス Chromium(SwiftShader)でシーンを実際に構築して、
各 `InstancedMesh` について r128 と同じ判定(`boundingSphere` を `matrixWorld` で変換した球)と、
インスタンス行列を考慮した真値を突き合わせて数えました。

カメラは軌道カメラをマニュアルモードに固定し、**原点が視錐台の外(カメラの背後)になる**
z ≒ -370 から進行方向(-Z)を向く、ドライバー視点に近い姿勢に置いています。

| 指標 | 実測 |
| --- | --- |
| シーン中の `InstancedMesh` | 31 個 |
| `frustumCulled` が有効なもの | **0 個**(r128 の既定で全て無効) |
| 実際に誤って消えているもの | **0 個** |
| 仮に `frustumCulled` が有効だったら誤って消えるもの | 18 個 / 755 インスタンス |

最終行が Issue の指摘した誤判定の実在を裏づけ、その上の 2 行が「現状は症状が出ない」ことを示します。

同じ姿勢でキャンバスを取得した描画結果でも、車線境界の破線・分離帯の緑ストリップとラバーポール・
ガードレールの支柱・街灯が正常に描画されていることを確認しました。

- `pnpm check`: pass(フォーマット 39 ファイル / lint・型チェック 31 ファイル、警告 0)
- `pnpm test`: 161 tests passed(L/R スコア差の回帰ガードを含む)
- `pnpm build`: 成功

## リスク

描画コストへの影響はありません。今回の変更で `frustumCulled` の値が変わるオブジェクトは
**並木の 2 個だけ**で、それ以外は r128 の既定値を明示し直しただけです。並木は 130 本を
2 つの `InstancedMesh` にまとめてあり、draw call は増えません。

## 補足

シミュレーション挙動には一切触れていません(`src/core/**` は変更なし)。
L 区間 / R 区間の差は「追いつかれた車両の義務」のみ、という不変条件は維持されています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBRGuQ4Doy7RW3UFLPc9ae
