### PR TITLE
fix: 横持ちスマホでパネルが重なりリセット/パラメータ調整室が押せない問題を解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,106 +27,115 @@
     </button>
     <div id="spectatorLabel"></div>
 
-    <!-- コントロールパネル（左上） -->
-    <div id="controlPanel" class="sign panel">
-      <button
-        type="button"
-        class="panel-title"
-        aria-expanded="true"
-        aria-controls="controlPanelBody"
-      >
-        <img class="app-icon" src="/traffic-jam.svg" alt="" />渋滞シミュレーション<span class="chev"
-          ><i data-lucide="chevron-down"></i
-        ></span>
-      </button>
-      <div id="controlPanelBody" class="panel-body">
-        <div class="row">
-          総車両数: <span class="num" id="vehicleCount">0</span> /
-          <span class="num" id="maxVehicleCount"></span>
-        </div>
-        <div class="row">
-          車両ペア生成間隔: <span class="num" id="intervalLabel">800</span> ms
-          <input type="range" id="intervalSlider" min="100" max="3000" step="50" value="800" />
-        </div>
-        <button id="resetBtn"><i data-lucide="rotate-ccw"></i>リセット</button>
-        <button id="paramsBtn" aria-haspopup="dialog">
-          <i data-lucide="sliders-horizontal"></i>パラメータ調整室
+    <!-- パネル配置レイヤー（コントロールパネルと情報パネルの位置関係をまとめて決める） -->
+    <div id="panelLayer">
+      <!-- コントロールパネル（左上） -->
+      <div id="controlPanel" class="sign panel">
+        <button
+          type="button"
+          class="panel-title"
+          aria-expanded="true"
+          aria-controls="controlPanelBody"
+        >
+          <img class="app-icon" src="/traffic-jam.svg" alt="" />渋滞シミュレーション<span
+            class="chev"
+            ><i data-lucide="chevron-down"></i
+          ></span>
         </button>
-        <div class="hint">
-          <i data-lucide="mouse"></i>ドラッグ: 視点回転 ／ ホイール: ズーム<br /><i
-            data-lucide="smartphone"
-          ></i
-          >スワイプ: 回転 ／ ピンチ: ズーム
+        <div id="controlPanelBody" class="panel-body">
+          <div class="row">
+            総車両数: <span class="num" id="vehicleCount">0</span> /
+            <span class="num" id="maxVehicleCount"></span>
+          </div>
+          <div class="row">
+            車両ペア生成間隔: <span class="num" id="intervalLabel">800</span> ms
+            <input type="range" id="intervalSlider" min="100" max="3000" step="50" value="800" />
+          </div>
+          <button id="resetBtn"><i data-lucide="rotate-ccw"></i>リセット</button>
+          <button id="paramsBtn" aria-haspopup="dialog">
+            <i data-lucide="sliders-horizontal"></i>パラメータ調整室
+          </button>
+          <div class="hint">
+            <i data-lucide="mouse"></i>ドラッグ: 視点回転 ／ ホイール: ズーム<br /><i
+              data-lucide="smartphone"
+            ></i
+            >スワイプ: 回転 ／ ピンチ: ズーム
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- 下部: 2区間の比較パネル(1枚) -->
-    <div id="infoPanel" class="sign panel" style="position: fixed">
-      <button type="button" class="panel-title" aria-expanded="true" aria-controls="infoPanelBody">
-        <span class="route-badge">比</span>渋滞スコア比較
-        <span class="mini-pair"
-          ><span class="mL" id="miniLeft">0.0</span><span class="sep">vs</span
-          ><span class="mR" id="miniRight">0.0</span></span
+      <!-- 下部: 2区間の比較パネル(1枚) -->
+      <div id="infoPanel" class="sign panel">
+        <button
+          type="button"
+          class="panel-title"
+          aria-expanded="true"
+          aria-controls="infoPanelBody"
         >
-        <span class="chev"><i data-lucide="chevron-down"></i></span>
-      </button>
-      <div id="infoPanelBody" class="panel-body">
-        <div class="compare">
-          <div class="side left">
-            <div class="crown" id="crownLeft"><i data-lucide="crown"></i>こちらがスムーズ</div>
-            <div class="side-head">
-              <span class="route-badge">義</span
-              ><i data-lucide="circle" class="dot dot-green"></i>義務あり
-            </div>
-            <div class="row">
-              車両数: <span class="num" id="countLeft">0</span> 台 ／ 平均
-              <span class="num" id="avgLeft">0</span> km/h
-            </div>
-            <div class="row" style="margin-bottom: 0">
-              渋滞スコア
-              <div class="score-line">
-                <span class="score-big" id="scoreLeft">0.0</span
-                ><span class="score-unit">/ 100</span>
+          <span class="route-badge">比</span>渋滞スコア比較
+          <span class="mini-pair"
+            ><span class="mL" id="miniLeft">0.0</span><span class="sep">vs</span
+            ><span class="mR" id="miniRight">0.0</span></span
+          >
+          <span class="chev"><i data-lucide="chevron-down"></i></span>
+        </button>
+        <div id="infoPanelBody" class="panel-body">
+          <div class="compare">
+            <div class="side left">
+              <div class="crown" id="crownLeft"><i data-lucide="crown"></i>こちらがスムーズ</div>
+              <div class="side-head">
+                <span class="route-badge">義</span
+                ><i data-lucide="circle" class="dot dot-green"></i>義務あり
               </div>
-              <div class="bar"><div id="barLeft"></div></div>
-              <div class="status" id="statusLeft"><i data-lucide="gauge"></i>スイスイ</div>
-            </div>
-            <div class="note">※ 速い車が来たら走行車線へ譲り、追い越し後はすぐ戻る</div>
-          </div>
-          <div class="seam"></div>
-          <div class="side right">
-            <div class="crown" id="crownRight"><i data-lucide="crown"></i>こちらがスムーズ</div>
-            <div class="side-head">
-              <span class="route-badge">自</span
-              ><i data-lucide="circle" class="dot dot-amber"></i>義務なし
-            </div>
-            <div class="row">
-              車両数: <span class="num" id="countRight">0</span> 台 ／ 平均
-              <span class="num" id="avgRight">0</span> km/h
-            </div>
-            <div class="row" style="margin-bottom: 0">
-              渋滞スコア
-              <div class="score-line">
-                <span class="score-big" id="scoreRight">0.0</span
-                ><span class="score-unit">/ 100</span>
+              <div class="row">
+                車両数: <span class="num" id="countLeft">0</span> 台 ／ 平均
+                <span class="num" id="avgLeft">0</span> km/h
               </div>
-              <div class="bar"><div id="barRight"></div></div>
-              <div class="status" id="statusRight"><i data-lucide="gauge"></i>スイスイ</div>
+              <div class="row" style="margin-bottom: 0">
+                渋滞スコア
+                <div class="score-line">
+                  <span class="score-big" id="scoreLeft">0.0</span
+                  ><span class="score-unit">/ 100</span>
+                </div>
+                <div class="bar"><div id="barLeft"></div></div>
+                <div class="status" id="statusLeft"><i data-lucide="gauge"></i>スイスイ</div>
+              </div>
+              <div class="note">※ 速い車が来たら走行車線へ譲り、追い越し後はすぐ戻る</div>
             </div>
-            <div class="note">※ 譲る義務がなく、追い越し車線に長居するマイペース派も混在</div>
+            <div class="seam"></div>
+            <div class="side right">
+              <div class="crown" id="crownRight"><i data-lucide="crown"></i>こちらがスムーズ</div>
+              <div class="side-head">
+                <span class="route-badge">自</span
+                ><i data-lucide="circle" class="dot dot-amber"></i>義務なし
+              </div>
+              <div class="row">
+                車両数: <span class="num" id="countRight">0</span> 台 ／ 平均
+                <span class="num" id="avgRight">0</span> km/h
+              </div>
+              <div class="row" style="margin-bottom: 0">
+                渋滞スコア
+                <div class="score-line">
+                  <span class="score-big" id="scoreRight">0.0</span
+                  ><span class="score-unit">/ 100</span>
+                </div>
+                <div class="bar"><div id="barRight"></div></div>
+                <div class="status" id="statusRight"><i data-lucide="gauge"></i>スイスイ</div>
+              </div>
+              <div class="note">※ 譲る義務がなく、追い越し車線に長居するマイペース派も混在</div>
+            </div>
           </div>
-        </div>
-        <!-- 開始からの累積: どちらが優勢だった時間が長いか(1本のバーを割合で分割) -->
-        <div class="smooth-time">
-          <div class="smooth-time-head">
-            <i data-lucide="timer"></i>優勢だった時間(開始から)
-            <span class="smooth-lead" id="smoothLead">互角</span>
-          </div>
-          <div class="smooth-time-bars">
-            <span class="smooth-side">義 <span class="num" id="smoothTimeLeft">0:00</span></span>
-            <div class="smooth-bar"><div id="smoothBarLeft"></div></div>
-            <span class="smooth-side"><span class="num" id="smoothTimeRight">0:00</span> 自</span>
+          <!-- 開始からの累積: どちらが優勢だった時間が長いか(1本のバーを割合で分割) -->
+          <div class="smooth-time">
+            <div class="smooth-time-head">
+              <i data-lucide="timer"></i>優勢だった時間(開始から)
+              <span class="smooth-lead" id="smoothLead">互角</span>
+            </div>
+            <div class="smooth-time-bars">
+              <span class="smooth-side">義 <span class="num" id="smoothTimeLeft">0:00</span></span>
+              <div class="smooth-bar"><div id="smoothBarLeft"></div></div>
+              <span class="smooth-side"><span class="num" id="smoothTimeRight">0:00</span> 自</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -98,6 +98,19 @@ canvas {
   color: #965c03;
   border-color: #965c03;
 }
+/* パネル配置レイヤー。
+   広い画面では各パネルの fixed 配置をそのまま使うため、レイヤー自体は
+   レイアウトに関与せず、クリックも透過させる(3Dビューの操作を邪魔しない)。
+   高さが足りない画面でだけ横並びのフレックスに切り替えてパネルの重なりを防ぐ */
+#panelLayer {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+}
+#panelLayer > * {
+  pointer-events: auto;
+}
 .panel {
   position: fixed;
   z-index: 10;
@@ -883,6 +896,56 @@ body.night #nightBtn {
   }
   .row {
     margin: 4px 0;
+  }
+}
+
+/* ---- 横持ちスマホなど「低い横長画面」のパネル配置 (Issue #51) ----
+   縦に余裕がない画面では、左上のコントロールパネルと下部の比較パネルが
+   空間的に重なってしまう。重なると
+   ・下になった側のボタン(リセット/パラメータ調整室)が押せず、
+     同じ座標にある相手のタイトル行が反応して誤操作になる
+   ・逆順に重なると比較パネルの義務あり側が完全に隠れ、
+     このアプリの主目的である L/R 比較が読めなくなる
+   z-index を入れ替えてもどちらかが隠れる点は変わらないため、
+   パネルを横並びにして「そもそも重ならない」配置にする。 */
+@media (max-height: 620px) and (min-width: 480px) {
+  #panelLayer {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px;
+  }
+  /* fixed をやめてフレックス項目にする。position は王冠(.crown)の
+     位置基準として必要なので relative を残す */
+  #panelLayer > .panel {
+    position: relative;
+    inset: auto;
+    transform: none;
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+    min-height: 0;
+  }
+  /* 幅は通常時の指定をそのまま使う(狭い画面では max-width:700px の指定が効く)。
+     ただし比較パネルの取り分がなくならないよう画面幅の 45% で頭打ちにする */
+  #controlPanel {
+    flex: 0 0 auto;
+    max-width: 45vw;
+    overflow: visible;
+  }
+  #infoPanel {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+    /* 操作パネルは上、比較パネルは下という元の並びの印象を保つ */
+    align-self: flex-end;
+  }
+  /* 画面が極端に低いときはタイトル行を残したまま中身だけスクロールさせる。
+     王冠は #infoPanel 基準の絶対配置なのでスクロール領域に切られない */
+  .panel-body {
+    overflow: auto;
+    min-height: 0;
+    overscroll-behavior: contain;
   }
 }
 


### PR DESCRIPTION
Closes #51

## 問題

高さの足りない横長画面（横持ちスマホ相当）では、左上の `#controlPanel` と下部の `#infoPanel` が空間的に重なっていました。2枚は同じ重なり順で、`bringToFront` により最後に触った方が手前に来るため、次の2つの症状が交互に起きます。

- 比較パネルが手前になると、**リセット/パラメータ調整室が押せない**。しかも押した座標には `#infoPanel .panel-title` があるため、タップは「スコア比較パネルの折りたたみ」として処理され、無反応ではなく**意図しない別の操作**になる。
- 逆順ではコントロールパネルが比較パネルを覆い、**義務あり側のバッジ・車両数・平均速度・スコアが完全に隠れる**。L/R 比較がこのアプリの主目的であるため実害が大きい。

## 方針

重なり順を入れ替えるだけでは「どちらかが隠れる」状況は変わらないため、**そもそも重ならない配置**にしました。

- 2枚のパネルを配置レイヤー `#panelLayer` で囲む（`index.html`）。
- 広い画面ではレイヤーはレイアウトに関与せず、各パネルのこれまでどおりの `fixed` 配置がそのまま効く。`pointer-events: none` としてあるので3Dビューのドラッグ操作も妨げない。
- `@media (max-height: 620px) and (min-width: 480px)` のときだけレイヤーを横並びのフレックスに切り替え、操作パネルを左・比較パネルを右に置いて重なりをなくす（操作パネルは上、比較パネルは下という元の並びの印象は `align-self` で保持）。
- 画面が極端に低い場合に備え、この配置のときはタイトル行を残したまま `.panel-body` だけがスクロールするようにした。王冠（`.crown`）は `#infoPanel` 基準の絶対配置なのでスクロール領域に切られない。

しきい値 620px は実測に基づきます（1024x600 でも修正前は重なりが発生していたため、520px では不足）。

## 変更ファイル

- `index.html` … パネル2枚を `#panelLayer` で囲む。`#infoPanel` の冗長なインライン `style="position: fixed"` を削除（`.panel` の指定と重複しており、メディアクエリでの配置切替を妨げるため）。差分の大半はネストが1段深くなったことによる再インデントです（`git diff -w` では実質12行の追加）。
- `src/style.css` … `#panelLayer` の定義と、低い横長画面向けの配置切替を追加。

シミュレーションのロジック（`src/core/**`）には一切触れていません。

## 検証

すべて実行して緑を確認しました。

| コマンド | 結果 |
| --- | --- |
| `pnpm check` | pass（39ファイル整形OK / 31ファイルで警告・lint・型エラーなし） |
| `pnpm test` | 161 tests passed (1 file) |
| `pnpm build` | 成功 |

さらに `dist/` を配信し Chromium (Playwright) で Issue の再現手順（起動 → 操作パネルの見出しをタップして展開 → 比較パネルをタップ → リセットをタップ）を自動でなぞり、2パネルの重なり面積・リセットのクリック到達・各表示要素の被覆を実測しました。

| ビューポート | 修正前 | 修正後 |
| --- | --- | --- |
| 844x390 | 重なり **20812px²** / リセットのクリックが `#infoPanel` に吸われ**発火せず** | 重なり **0px²** / リセットに**クリック到達**、L/R のバッジ・車両数・平均速度・スコアがすべて可視 |
| 667x375 | リセット位置のタップが比較パネルの見出しに当たり、**スコア比較が折りたたまれる誤操作** | 重なり **0px²** / リセットに**クリック到達**、L/R の各値が可視 |
| 1024x600 | 重なり **820px²** | 重なり **0px²** |
| 1280x800 | — | パネルの矩形が修正前後で完全一致（`cp {12,12,264,291}` / `ip {310,481,970,788}`）＝**既存の見た目に変化なし** |
| 390x844（縦持ち） | — | 同上、矩形一致で変化なし |

スクリーンショットでも、修正前は比較パネルがリセット/パラメータ調整室のボタンを覆っていたのに対し、修正後は左に操作パネル・右に比較パネルが並び、両方の内容が同時に読める状態になっていることを確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBRGuQ4Doy7RW3UFLPc9ae
