### PR TITLE
fix: sectionIndex の陳腐化で findAhead が最近接の前方車を見落とす問題を修正 (#52)

### DIFF
--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -201,7 +201,6 @@ export class Vehicle {
   exited: boolean;
   waitTimer: number;
   perturbTimer: number;
-  sectionIndex: number;
   color: number;
   isTaxi: boolean;
   absorber: boolean;
@@ -288,7 +287,6 @@ export class Vehicle {
     this.exited = false; // 出口まで走り切って流出した(Worldが回収する)
     this.waitTimer = 0;
     this.perturbTimer = 0; // よそ見ブレーキの残り時間(absorbモードでWorldが設定)
-    this.sectionIndex = 0;
     this.color = this.type.colors[Math.floor(random() * this.type.colors.length)];
     this.isTaxi = typeName === 'Sedan' && random() < 0.08;
     if (this.isTaxi) this.color = 0xf5f0dc;
@@ -1080,45 +1078,41 @@ export class Vehicle {
     return true;
   }
 
-  // 前方車探索（z昇順インデックスを利用。ahead = z が小さい側。周回路として探索）
-  findAhead(lane: number): NeighborInfo | null {
+  /**
+   * 周回路上で最も近い同一車線の隣接車を返す。ahead = true で前方(z が小さい側)。
+   *
+   * sectionVehicles は step 冒頭の rebuildSectionIndex() で z 昇順に並べ替えられるが、
+   * その後の update ループで各車が移動するため、step の途中では並び順が崩れている
+   * (特に周回した車は z が +WRAP_LENGTH され、配列の末尾にあるべき位置へ飛ぶ)。
+   * そのため添字順の走査で「最初に見つかった一台」を返すことはできず、
+   * リング上の一方向距離が最小の一台を選び直す (Issue #52)。
+   */
+  private findNeighbor(lane: number, ahead: boolean): NeighborInfo | null {
     const vehicles = this.world.sectionVehicles[this.section];
-    for (let i = this.sectionIndex - 1; i >= 0; i--) {
-      const other = vehicles[i];
+    let best: Vehicle | null = null;
+    let bestDistance = Infinity;
+    for (const other of vehicles) {
       if (other === this || !other.occupies(lane)) continue;
-      if (other.z >= this.z) continue;
-      return { vehicle: other, gap: this.z - other.z - (this.length + other.length) / 2 };
+      const raw = ahead ? this.z - other.z : other.z - this.z;
+      // リング上の一方向距離 (0, WRAP_LENGTH]。
+      // 距離 0(完全に同じ z)は従来と同じく「一周先」として扱う。
+      const distance = ((raw % WRAP_LENGTH) + WRAP_LENGTH) % WRAP_LENGTH || WRAP_LENGTH;
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = other;
+      }
     }
-    // 周回: 自分より手前に誰もいなければ、最も奥(z最大)の同一車線車が前方
-    for (let i = vehicles.length - 1; i > this.sectionIndex; i--) {
-      const other = vehicles[i];
-      if (other === this || !other.occupies(lane)) continue;
-      return {
-        vehicle: other,
-        gap: this.z - other.z + WRAP_LENGTH - (this.length + other.length) / 2,
-      };
-    }
-    return null;
+    if (best === null) return null;
+    return { vehicle: best, gap: bestDistance - (this.length + best.length) / 2 };
+  }
+
+  // 前方車探索（ahead = 進行方向側 = z が小さい側。周回路として探索）
+  findAhead(lane: number): NeighborInfo | null {
+    return this.findNeighbor(lane, true);
   }
 
   findBehind(lane: number): NeighborInfo | null {
-    const vehicles = this.world.sectionVehicles[this.section];
-    for (let i = this.sectionIndex + 1; i < vehicles.length; i++) {
-      const other = vehicles[i];
-      if (other === this || !other.occupies(lane)) continue;
-      if (other.z < this.z) continue;
-      return { vehicle: other, gap: other.z - this.z - (this.length + other.length) / 2 };
-    }
-    // 周回: 自分より奥に誰もいなければ、最も手前(z最小)の車が後続
-    for (let i = 0; i < this.sectionIndex; i++) {
-      const other = vehicles[i];
-      if (other === this || !other.occupies(lane)) continue;
-      return {
-        vehicle: other,
-        gap: other.z - this.z + WRAP_LENGTH - (this.length + other.length) / 2,
-      };
-    }
-    return null;
+    return this.findNeighbor(lane, false);
   }
 
   // 車線変更先の安全確認: 'safe' | 'hold' | 'danger'

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -780,6 +780,14 @@ export class World {
     this.rebuildSectionIndex();
   }
 
+  /**
+   * 区間ごとの走行中車両リストを作り直す。step 冒頭に一度だけ呼ぶ。
+   *
+   * z 昇順に並べるが、この並び順は「step 冒頭の縦列を見たい」用途
+   * (貫通チェックなど) のためのものである。update ループの途中では各車が
+   * 移動して順序が崩れるため、前後車の探索がこの並び順に依存してはならない
+   * (Issue #52)。探索は Vehicle#findNeighbor がリング上の距離で行う。
+   */
   rebuildSectionIndex(): void {
     const vehiclesL: Vehicle[] = [],
       vehiclesR: Vehicle[] = [];
@@ -787,8 +795,6 @@ export class World {
       if (!vehicle.waiting) (vehicle.section === 'L' ? vehiclesL : vehiclesR).push(vehicle);
     vehiclesL.sort((a, b) => a.z - b.z);
     vehiclesR.sort((a, b) => a.z - b.z);
-    for (let i = 0; i < vehiclesL.length; i++) vehiclesL[i].sectionIndex = i;
-    for (let i = 0; i < vehiclesR.length; i++) vehiclesR[i].sectionIndex = i;
     this.sectionVehicles.L = vehiclesL;
     this.sectionVehicles.R = vehiclesR;
   }

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -3411,3 +3411,134 @@ describe('車線変更安全確認の周回考慮 (Issue #50)', () => {
     expect(right.mover.checkLaneSafetyForChange(1)).toBe(left.mover.checkLaneSafetyForChange(1));
   });
 });
+
+/* ============================================================
+   前方車探索の並べ替え耐性 (Issue #52)
+   sectionVehicles は step 冒頭の rebuildSectionIndex() で一度だけ z 昇順に
+   並べ替えられるが、その後の update ループで各車が移動する。とりわけ周回した
+   車は z が +WRAP_LENGTH されるため、step の途中で配列の z 昇順は必ず崩れる。
+   添字順に走査して最初の一台を返す実装では、より近い車を飛ばして遠い車を
+   返したり、前方車そのものを見失ったりしていた。
+   リング上の一方向距離が最小の一台を選び直す、区間非依存の修正である。
+   ============================================================ */
+describe('前方車探索の並べ替え耐性 (Issue #52)', () => {
+  // 参照実装。配列の並び順に一切依存せず、リング上で最も近い同一車線の
+  // 前方車(ahead=true) / 後方車(ahead=false) をブルートフォースで求める。
+  function referenceNeighbor(self: Vehicle, lane: number, ahead: boolean) {
+    let best: Vehicle | null = null;
+    let bestDistance = Infinity;
+    for (const other of self.world.sectionVehicles[self.section]) {
+      if (other === self || !other.occupies(lane)) continue;
+      const raw = ahead ? self.z - other.z : other.z - self.z;
+      const distance = ((raw % WRAP_LENGTH) + WRAP_LENGTH) % WRAP_LENGTH || WRAP_LENGTH;
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = other;
+      }
+    }
+    return best === null
+      ? null
+      : { vehicle: best, gap: bestDistance - (self.length + best.length) / 2 };
+  }
+
+  // Issue 記載の再現ケース。step 冒頭では W が V の 4.90m 前方だが、同一 step 内で
+  // W.update() が走って周回すると z が +WRAP_LENGTH され、配列の z 昇順が崩れる。
+  function setupWrappedLeader(section: 'L' | 'R') {
+    const world = new World({ rng: createRng(52), spawnInterval: 1e9 });
+    const leader = new Vehicle(world, section, 1, -407.5, 'Sedan', 25);
+    leader.speed = 25;
+    const follower = new Vehicle(world, section, 1, -398, 'Sedan', 25);
+    follower.speed = 25;
+    world.vehicles.push(leader, follower);
+    world.rebuildSectionIndex();
+    // 並べ替え直後は素直な前後関係になっている
+    expect(follower.findAhead(1)?.vehicle, '並べ替え直後に前方車を取り違えた').toBe(leader);
+    expect(follower.findAhead(1)!.gap).toBeCloseTo(4.9, 5);
+    // step の途中で W だけが周回した状態を作る(並べ替えはやり直さない)
+    leader.z = 407.26;
+    return { world, leader, follower };
+  }
+
+  test('step 途中で周回した前方車を見失わない', () => {
+    const { leader, follower } = setupWrappedLeader('L');
+    const ahead = follower.findAhead(1);
+    expect(ahead, '周回した前方車を見失って null を返した').not.toBeNull();
+    expect(ahead!.vehicle).toBe(leader);
+    // リング上の真の車間: -398 - 407.26 を周回長で畳むと 10.74m、車体分を引いて 6.14m
+    expect(ahead!.gap, 'リング上の車間が正しく計算されていない').toBeCloseTo(6.14, 2);
+  });
+
+  test('周回した車から見た後方車も正しく返す', () => {
+    const { leader, follower } = setupWrappedLeader('L');
+    const behind = leader.findBehind(1);
+    expect(behind, '周回後に後続車を見失った').not.toBeNull();
+    expect(behind!.vehicle).toBe(follower);
+    expect(behind!.gap).toBeCloseTo(6.14, 2);
+  });
+
+  test('L/R で同一の結果になる (区間依存の分岐が入っていない)', () => {
+    const left = setupWrappedLeader('L');
+    const right = setupWrappedLeader('R');
+    expect(right.follower.findAhead(1)!.gap).toBeCloseTo(left.follower.findAhead(1)!.gap, 9);
+    expect(right.leader.findBehind(1)!.gap).toBeCloseTo(left.leader.findBehind(1)!.gap, 9);
+  });
+
+  test('前方車は必ず最近接になる (遠い車を先に返さない)', () => {
+    const world = new World({ rng: createRng(522), spawnInterval: 1e9 });
+    const self = new Vehicle(world, 'L', 1, 0, 'Sedan', 25);
+    const near = new Vehicle(world, 'L', 1, -20, 'Sedan', 25);
+    const far = new Vehicle(world, 'L', 1, -300, 'Sedan', 25);
+    for (const vehicle of [self, near, far]) vehicle.speed = 25;
+    world.vehicles.push(self, near, far);
+    world.rebuildSectionIndex();
+    const before = self.findAhead(1)!;
+    expect(before.vehicle, '近い方を飛ばして遠い前方車を返した').toBe(near);
+    expect(before.gap).toBeCloseTo(15.4, 5);
+    // 周回長ちょうどを足してもリング上の位置は一切変わらない。変わるのは配列の
+    // z 昇順だけである。添字順に走査する実装はここで near を飛ばして far を返し、
+    // 車間を 15.4m から 295.4m へ 280m も過大に報告していた。
+    near.z += WRAP_LENGTH;
+    const after = self.findAhead(1)!;
+    expect(after.vehicle, '並び順が崩れた途端に近い前方車を飛ばして far を返した').toBe(near);
+    expect(after.gap, 'リング上の位置は変わっていないのに車間が変化した').toBeCloseTo(15.4, 5);
+    // 一方 far は、リング上では自分の 516m 後方にいる最近接の後続車である
+    expect(self.findBehind(1)!.vehicle).toBe(far);
+  });
+
+  test('配列の z 昇順が崩れてもブルートフォースと完全に一致する', () => {
+    const random = createRng(520);
+    const world = new World({ rng: createRng(521), spawnInterval: 1e9 });
+    for (let i = 0; i < 40; i++) {
+      const vehicle = new Vehicle(
+        world,
+        i % 2 === 0 ? 'L' : 'R',
+        Math.floor(random() * 3),
+        random() * WRAP_LENGTH - CONST.ROAD_HALF,
+        'Sedan',
+        25,
+      );
+      vehicle.speed = 25;
+      world.vehicles.push(vehicle);
+    }
+    world.rebuildSectionIndex();
+    // 並べ替えた後に位置を動かして z 昇順を崩す(周回した車も混ざる)
+    for (const vehicle of world.vehicles) vehicle.z += random() * WRAP_LENGTH;
+    for (const vehicle of world.vehicles) {
+      for (const lane of [0, 1, 2]) {
+        const expectedAhead = referenceNeighbor(vehicle, lane, true);
+        const actualAhead = vehicle.findAhead(lane);
+        expect(actualAhead?.vehicle ?? null, `lane=${lane} の前方車が最近接でない`).toBe(
+          expectedAhead?.vehicle ?? null,
+        );
+        if (expectedAhead) expect(actualAhead!.gap).toBeCloseTo(expectedAhead.gap, 9);
+
+        const expectedBehind = referenceNeighbor(vehicle, lane, false);
+        const actualBehind = vehicle.findBehind(lane);
+        expect(actualBehind?.vehicle ?? null, `lane=${lane} の後方車が最近接でない`).toBe(
+          expectedBehind?.vehicle ?? null,
+        );
+        if (expectedBehind) expect(actualBehind!.gap).toBeCloseTo(expectedBehind.gap, 9);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #52

> [!IMPORTANT]
> **#50 の上に積む stacked PR です。** base は `main` ではなく `fix/50-wrap-lane-safety` (#91) です。
> 差分を単体で読む場合は #91 のマージ後に見てください。

## 問題

`sectionVehicles` は step 冒頭の `rebuildSectionIndex()` で **一度だけ** z 昇順に並べ替えられるが、その後の update ループで各車が移動する。とりわけ周回した車は `z` が `+WRAP_LENGTH` されるため、配列上のあるべき位置から大きく離れる。**step の途中では配列の z 昇順は必ず崩れている。**

`findAhead` / `findBehind` は添字順に走査して最初に見つかった一台を返していたため、より近い車を飛ばして遠い車を返し、車間を過大に報告していた。当該フレームでその車は「前方がガラ空き」と誤認して減速せず、さらに `decide()` にも誤った `ahead` が渡るため、追い越し判断・復帰判断・渋滞中の乗り換え判断がすべて誤った入力で走っていた。

## 変更内容

- 添字順の走査という前提そのものが壊れているため、**リング上の一方向距離が最小の一台を選び直す**方式へ変更した。探索は `Vehicle#findNeighbor(lane, ahead)` に一本化し、`findAhead` / `findBehind` はその薄いラッパーにした。
- 陳腐化の実体であった `Vehicle#sectionIndex` は参照元が無くなったため**削除**した(これにより同種の再発が型レベルで不可能になる)。
- `rebuildSectionIndex()` の z 昇順そのものは、貫通チェックなど「step 冒頭の縦列」を見る用途で引き続き必要なので**残した**。並び順に依存してよい範囲をコメントで明記した。

### 実験的妥当性について

修正は **L/R 完全同一(区間非依存)** であり、`section` / `yields` / `camper` / `keepLeft` / `returnTime` を一切参照しない。
また **並べ替え直後の配列に対しては従来実装と同じ結果を返す**ため、挙動が変わるのは「並び順が崩れているケース」だけに限定される。

## 実測値

10 シード × 300 秒、120 秒以降を測定、`spawnInterval = 800`。計測スクリプトは untracked のまま、コミットには含めていない。

### `findAhead` の誤り

| 指標 | #50 のみ | #50+#52 |
| --- | --- | --- |
| findAhead 呼び出し回数 | 11,214,168 | 11,570,685 |
| 車間を 5m 以上過大に返した回数 | **12,032** | **0** |
| 最大過大量 | 454.6m | 0m |

- Issue 本文の実測値(11,374 回 / 最大 338.8m)とは計測実装が異なるため数値がずれるが、桁と傾向は一致している。
- 修正後の 0 は**構成上そうなる**点に注意。計測はブルートフォースのリング最近接を参照実装として比較しており、修正後の `findAhead` はまさにそれを計算している。したがってこの 0 は「実装が参照実装と一致している」ことの確認であって、独立した証拠ではない。独立した証拠はテストの方(下記)にある。

### L/R 渋滞スコア差

| | main のみ | #50 のみ | **#50+#52** |
| --- | --- | --- | --- |
| 10 シード平均 | 8.675 | 3.682 | **4.003** |

シード別 (#50+#52):

| seed | 11 | 22 | 33 | 44 | 55 | 66 | 77 | 88 | 99 | 110 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 差 | 4.697 | 1.923 | 5.523 | 9.191 | 1.780 | 4.128 | 4.412 | 3.472 | 1.253 | 3.649 |

**#52 はスコア差をほとんど回復させない**(3.682 → 4.003)。回帰ガードの下限 7 には遠く、**再較正は依然として必要**である。一方で分散は縮んでおり(#50 のみでは 0.263〜10.983、本 PR では 1.253〜9.191)、全シードで符号の逆転は起きていない。

### 車線変更数

| | #50 のみ | #50+#52 |
| --- | --- | --- |
| L (義務あり) | 4948 | 4885 |
| R (義務なし) | 2988 | 2983 |

## テスト

`traffic-simulation.test.ts` 末尾に新規セクション **`前方車探索の並べ替え耐性 (Issue #52)`** を追加した(既存 describe とは重複しない)。

- **Issue 記載の再現ケース**: `W.z = -407.50` / `V.z = -398.00` で並べ替えた後、W だけが `z = 407.26` へ周回した状態を作る。修正前は `V.findAhead(1)` が前方車を見失っていた。修正後は W を返し、リング上の車間 **6.14m** を正しく返す。
- 周回した W 側から見た `findBehind` も対称に検証。
- **最近接であることの検証**: 周回長ちょうどを足してもリング上の位置は変わらないのに、添字順の実装は近い車を飛ばして遠い車を返し、車間を 15.4m → 295.4m と **280m 過大**に報告していた。これを直接押さえている。
- **ブルートフォースとの完全一致**: 40 台を配置して並べ替えた後に位置をランダムに動かし z 昇順を崩したうえで、全車 × lane 0〜2 について `findAhead` / `findBehind` が参照実装と車両・車間ともに一致することを確認する。
- L/R で結果が一致することの検証(区間依存の分岐が入っていないこと)。

## 落ちているテスト(4 件)

`pnpm check` は green。`pnpm test` は **4 failed | 167 passed (171)**。

閾値・期待値・較正パラメータは**一切変更していない**。#50+#52 を揃えてから区間非依存で再較正する方針のため、意図的に落ちたままにしてある。

| # | テスト | 実測値 | #50 のみでも落ちるか |
| --- | --- | --- | --- |
| 1 | 10シード平均のスコア差が 7〜12 に収まる | 平均差 **4.003** (下限 7 未満) | ✅ 落ちる(既知) |
| 2 | 義務なし区間: 加速して前に出て復帰する | 復帰できず `false` | ✅ 落ちる(既知) |
| 3 | 混雑側(義務なし)に車両が滞留し、平均台数が多くなる | 平均台数差 R-L = **0.050** (要 > 1) | ✅ 落ちる(既知。#50 のみでは 0.107) |
| 4 | 流入需要は左右同ペース(混雑側の流入が上回ることはない) | seed=66 で R 流入 **35** > L **34** | ⚠️ **本 PR で新たに落ちた** |

> [!WARNING]
> **4 は本 PR で新規に落ちたもの**である。base (`fix/50-wrap-lane-safety`) で当該テストだけを実行して確認したところ、そちらでは通る(`1 failed | 10 passed`、落ちるのは 3 のみ)。
>
> 内容は **10 シード中 seed=66 の 1 シードのみで、流入台数が 35 対 34 と 1 台差で逆転した**というもの。#52 により軌道が変わった結果の閾値際の揺れであり、区間依存のロジックを導入したことによるものではない(本 PR の変更は L/R 完全同一)。とはいえ「混雑側の流入が上回らない」という不変条件に 1 台差で触れているため、**再較正時に併せて評価すべき項目**として明示的に残す。指示通り期待値を緩める対処は行っていない。

## 未検証事項

- 貫通(最小車間)の #50+#52 での実測は本 PR では取得できていない。#53 側の強化された貫通テストでの評価が望ましい。
- `findNeighbor` は早期打ち切りができず区間全車を走査するため、`findAhead` は O(n) になった(従来は並びが正しい限り近傍で打ち切れていた)。同ファイルの `checkLaneSafetyForChange` / `findAlongside` 等は元々全走査であり、テスト実行時間にも顕著な悪化は見られなかったが、車両数上限(190/区間)付近での描画フレームレートは実機確認の価値がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBRGuQ4Doy7RW3UFLPc9ae
