### PR TITLE
テスト: 貫通検査を同一車線の全前後ペア・リング全周へ拡張 (Issue #53)

### DIFF
--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -47,7 +47,84 @@ interface ScenarioResult {
   countR: number;
   minGap: number;
   minGapDetail: string;
+  /** 検査した「同一車線の前後ペア」の延べ数(検出力そのものの回帰ガード用) */
+  checkedPairs: number;
+  /** 車間が負 = 実際に車体が重なっていたペアの延べ数 */
+  overlaps: number;
   world: World;
+}
+
+/* ---------- ヘルパー: 貫通(同一車線内の重なり)検査 (Issue #53) ---------- */
+interface PenetrationPair {
+  section: 'L' | 'R';
+  lane: number;
+  ahead: Vehicle;
+  behind: Vehicle;
+  /** 後続から前方車までの周回路上の前方距離 (m) */
+  distance: number;
+  /** 車体間の車間 (m)。負なら重なっている */
+  gap: number;
+}
+interface PenetrationResult {
+  pairs: number;
+  overlaps: number;
+  minGap: number;
+  /** 最小車間を記録したペア。ペアが1つも無ければ null */
+  worst: PenetrationPair | null;
+}
+
+/**
+ * ある瞬間のワールドについて、同一車線の「真の前後ペア」を漏れなく検査する (Issue #53)。
+ *
+ * 旧実装は「区間全体を z 昇順に並べた配列の隣接 index」だけを見ていた。そのため
+ *   (1) 同一車線の前後ペアの間に他車線の車が1台でも挟まるとそのペアは永久に漏れる
+ *   (2) 周回の継ぎ目ペア(配列の端と端)を比較しない
+ *   (3) 距離が Math.abs(z 差) で周回非対応
+ * という3つの穴があり、実測では真の前後ペアの約1割しか比較できていなかった。
+ *
+ * ここでは車線ごとにグルーピングしてから z 昇順に並べ、リング上の隣接ペアを
+ * 全件見る。計算量は車線ごとのソートで O(N log N) に収まる。
+ */
+function checkPenetration(world: World): PenetrationResult {
+  let pairs = 0,
+    overlaps = 0,
+    minGap = Infinity;
+  let worst: PenetrationPair | null = null;
+  for (const section of ['L', 'R'] as const) {
+    const byLane = new Map<number, Vehicle[]>();
+    for (const vehicle of world.sectionVehicles[section]) {
+      // 車線変更中の車は occupies() が示すとおり2車線にまたがっており、
+      // 「どちらの車線に居るか」が定まらない。重なりの定義が曖昧になるため除外する
+      // (この除外は旧実装と同じ。除外を外すと車線変更のたびに偽陽性が出る)
+      if (vehicle.laneChange.state !== 'none') continue;
+      const group = byLane.get(vehicle.lane);
+      if (group) group.push(vehicle);
+      else byLane.set(vehicle.lane, [vehicle]);
+    }
+    for (const [lane, group] of byLane) {
+      if (group.length < 2) continue;
+      group.sort((a, b) => a.z - b.z); // 前方 = z が小さい側
+      for (let k = 0; k < group.length; k++) {
+        // k=0 は周回の継ぎ目ペア: z 最小(最前方)の車の前方は、一周回った先の
+        // z 最大の車。貫通が起きやすい継ぎ目こそ盲点にしてはならない
+        const behind = group[k],
+          ahead = group[(k + group.length - 1) % group.length];
+        // 前方距離は [0, WRAP_LENGTH) で測る。Vehicle.findAhead が周回時に
+        // `this.z - other.z + WRAP_LENGTH` としているのと同じ尺度。
+        // 符号付き最短の wrapDelta を使うと、周回しない加速車線(lane 3)の
+        // 継ぎ目ペアのように半周を超える距離が負へ折り返り誤検出になる
+        const distance = (((behind.z - ahead.z) % WRAP_LENGTH) + WRAP_LENGTH) % WRAP_LENGTH;
+        const gap = distance - (ahead.length + behind.length) / 2;
+        pairs++;
+        if (gap < 0) overlaps++;
+        if (gap < minGap) {
+          minGap = gap;
+          worst = { section, lane, ahead, behind, distance, gap };
+        }
+      }
+    }
+  }
+  return { pairs, overlaps, minGap, worst };
 }
 
 function runScenario(seed: number, opts: ScenarioOptions = {}): ScenarioResult {
@@ -60,40 +137,37 @@ function runScenario(seed: number, opts: ScenarioOptions = {}): ScenarioResult {
     sumCountL = 0,
     sumCountR = 0,
     samples = 0,
-    minGap = Infinity;
+    minGap = Infinity,
+    checkedPairs = 0,
+    overlaps = 0;
   let minGapDetail = '';
   const steps = Math.round(seconds / TIME_STEP);
   for (let i = 0; i < steps; i++) {
     world.step(TIME_STEP);
     const elapsed = i * TIME_STEP;
     if (i % 10 === 0) {
-      // 貫通チェック（同一車線・車線変更中でない車両同士）
-      for (const section of ['L', 'R'] as const) {
-        const vehicles = world.sectionVehicles[section];
-        for (let k = 1; k < vehicles.length; k++) {
-          const ahead = vehicles[k - 1],
-            behind = vehicles[k];
-          if (ahead.laneChange.state !== 'none' || behind.laneChange.state !== 'none') continue;
-          if (ahead.lane !== behind.lane) continue;
-          const gap = Math.abs(behind.z - ahead.z) - (ahead.length + behind.length) / 2;
-          if (gap < minGap) {
-            minGap = gap;
-            const activeClosures = world.vehicles
-              .filter((vehicle) => vehicle.mergePlan.certificate)
-              .map((vehicle) => ({
-                ramp: vehicle.spawnOrder,
-                lane: vehicle.lane,
-                state: vehicle.mergePlan.state,
-                targetPassTime: vehicle.mergePlan.certificate!.targetPassTime,
-                orders: vehicle.mergePlan.certificate!.closure.orders,
-                edges: vehicle.mergePlan.certificate!.closure.edges,
-              }));
-            minGapDetail =
-              `seed=${seed},time=${world.time},section=${section},` +
-              `ahead=${ahead.spawnOrder}@${ahead.z},behind=${behind.spawnOrder}@${behind.z},` +
-              `speed=${ahead.speed}/${behind.speed},closures=${JSON.stringify(activeClosures)}`;
-          }
-        }
+      // 貫通チェック(同一車線・車線変更中でない車両同士を、リング全周にわたり漏れなく)
+      const penetration = checkPenetration(world);
+      checkedPairs += penetration.pairs;
+      overlaps += penetration.overlaps;
+      if (penetration.worst && penetration.minGap < minGap) {
+        minGap = penetration.minGap;
+        const { section, lane, ahead, behind, distance } = penetration.worst;
+        const activeClosures = world.vehicles
+          .filter((vehicle) => vehicle.mergePlan.certificate)
+          .map((vehicle) => ({
+            ramp: vehicle.spawnOrder,
+            lane: vehicle.lane,
+            state: vehicle.mergePlan.state,
+            targetPassTime: vehicle.mergePlan.certificate!.targetPassTime,
+            orders: vehicle.mergePlan.certificate!.closure.orders,
+            edges: vehicle.mergePlan.certificate!.closure.edges,
+          }));
+        minGapDetail =
+          `seed=${seed},time=${world.time},section=${section},lane=${lane},` +
+          `ahead=${ahead.spawnOrder}@${ahead.z},behind=${behind.spawnOrder}@${behind.z},` +
+          `distance=${distance},speed=${ahead.speed}/${behind.speed},` +
+          `closures=${JSON.stringify(activeClosures)}`;
       }
       if (elapsed >= measureFrom) {
         const statsL = world.computeSection('L'),
@@ -113,6 +187,8 @@ function runScenario(seed: number, opts: ScenarioOptions = {}): ScenarioResult {
     countR: sumCountR / samples,
     minGap,
     minGapDetail,
+    checkedPairs,
+    overlaps,
     world,
   };
 }
@@ -338,14 +414,23 @@ describe('加速復帰（追いつかれ時に並走車を抜いて戻る）', (
    4. 安全性: 車両の貫通防止
    ============================================================ */
 describe('衝突回避・貫通防止', () => {
-  test('長時間運転しても同一車線内で車両が重ならない (許容 -1.0m)', () => {
-    let worstGap = Infinity;
-    for (const result of getResults()) worstGap = Math.min(worstGap, result.minGap);
+  test('長時間運転しても同一車線内で車両が重ならない', () => {
+    let worstGap = Infinity,
+      overlaps = 0;
+    for (const result of getResults()) {
+      worstGap = Math.min(worstGap, result.minGap);
+      overlaps += result.overlaps;
+    }
     const result = getResults().find((entry) => entry.minGap === worstGap)!;
+    // 車間 0m = 前後の車体が触れる境界。これを下回ったら車体が重なっている
+    // = 貫通であり、シミュレーションとして成立しない。
+    // 旧しきい値の -1.0m は「1m めり込んでも合格」で、貫通防止という
+    // テストの目的に対して意味を成していなかった (Issue #53)。
     expect(
-      worstGap,
-      `車間が ${worstGap.toFixed(2)}m まで縮まり貫通が発生: ${result.minGapDetail}`,
-    ).toBeGreaterThan(-1.0);
+      overlaps,
+      `同一車線で車体が重なったペアが ${overlaps} 件` +
+        ` (最小車間 ${worstGap.toFixed(2)}m): ${result.minGapDetail}`,
+    ).toBe(0);
   });
 });
 
@@ -3317,5 +3402,90 @@ describe('車両数上限の区間独立性 (Issue #72)', () => {
       CONST.MAX_VEHICLES,
       `総上限 ${CONST.MAX_VEHICLES}台 !== 片側上限 ${CONST.MAX_VEHICLES_PER_SECTION}台の2倍`,
     ).toBe(CONST.MAX_VEHICLES_PER_SECTION * 2);
+  });
+});
+
+/* ============================================================
+   29. 貫通検査のカバレッジ (Issue #53)
+   貫通(同一車線内の重なり)検査そのものの検出力を検証する。
+   旧実装は「区間全体の z 昇順配列の隣接 index」だけを見ていたため、
+   同一車線の真の前後ペアのうち約1割しか比較できていなかった。
+   ここでは checkPenetration が
+     (a) 他車線の車が間に挟まっても同一車線ペアを見る
+     (b) 周回の継ぎ目ペアを見る
+     (c) 距離をラップ対応で測る
+   を満たすことを、意図的に作った配置で確認する。
+   ============================================================ */
+describe('貫通検査のカバレッジ (Issue #53)', () => {
+  function makeWorld(): World {
+    return new World({ rng: createRng(53), spawnInterval: 1e9 });
+  }
+
+  test('同一車線ペアの間に他車線の車が挟まっても検査される', () => {
+    const world = makeWorld();
+    // z 昇順に並べると lane1 → lane0 → lane1 となり、隣接 index だけを見る
+    // 旧方式では lane1 同士の重なりが永久に検査対象から漏れる配置
+    const ahead = new Vehicle(world, 'L', 1, 0, 'Sedan', 25);
+    const between = new Vehicle(world, 'L', 0, 1.5, 'Sedan', 25);
+    const behind = new Vehicle(world, 'L', 1, 3, 'Sedan', 25);
+    world.vehicles.push(ahead, between, behind);
+    world.rebuildSectionIndex();
+
+    const result = checkPenetration(world);
+    expect(result.overlaps, '他車線に挟まれた同一車線ペアの重なりを見逃した').toBe(1);
+    // 車間 = 3m(車頭間) - 4.6m(Sedan 2台の半長の和)
+    expect(result.minGap).toBeCloseTo(3 - 4.6, 6);
+  });
+
+  test('周回の継ぎ目ペア(z 最小 → z 最大)も検査される', () => {
+    const world = makeWorld();
+    // リング上では 2m しか離れていないが、z の差は 814m ある配置。
+    // 継ぎ目ペアを比較しない、あるいは Math.abs(z 差) で測ると見逃す
+    const behind = new Vehicle(world, 'L', 1, -407, 'Sedan', 25);
+    const ahead = new Vehicle(world, 'L', 1, 407, 'Sedan', 25);
+    world.vehicles.push(behind, ahead);
+    world.rebuildSectionIndex();
+
+    const result = checkPenetration(world);
+    expect(result.pairs, '継ぎ目ペアが検査されていない').toBe(2);
+    expect(result.overlaps, '継ぎ目をまたぐ重なりを見逃した').toBe(1);
+    expect(result.minGap).toBeCloseTo(WRAP_LENGTH - 814 - 4.6, 6);
+  });
+
+  test('周回しない加速車線(lane 3)の継ぎ目ペアを重なりと誤検出しない', () => {
+    const world = makeWorld();
+    // 加速車線は本線と違い周回しない。ラップ距離を符号付き最短(wrapDelta)で
+    // 測ると半周を超える継ぎ目ペアが負に折り返り、存在しない貫通を報告する
+    const ahead = new Vehicle(world, 'L', 3, CONST.RAMP_Z_END, 'Sedan', 25);
+    const behind = new Vehicle(world, 'L', 3, CONST.RAMP_Z_TOP, 'Sedan', 25);
+    world.vehicles.push(ahead, behind);
+    world.rebuildSectionIndex();
+
+    const result = checkPenetration(world);
+    expect(result.overlaps, '周回しない車線で存在しない重なりを誤検出した').toBe(0);
+    expect(result.minGap).toBeCloseTo(CONST.RAMP_Z_TOP - CONST.RAMP_Z_END - 4.6, 6);
+  });
+
+  test('車線変更中の車は対象外(どちらの車線に居るか定まらないため)', () => {
+    const world = makeWorld();
+    const ahead = new Vehicle(world, 'L', 1, 0, 'Sedan', 25);
+    const behind = new Vehicle(world, 'L', 1, 3, 'Sedan', 25);
+    behind.laneChange.state = 'changing';
+    behind.laneChange.from = 2;
+    behind.laneChange.to = 1;
+    world.vehicles.push(ahead, behind);
+    world.rebuildSectionIndex();
+
+    expect(checkPenetration(world).pairs).toBe(0);
+  });
+
+  test('シナリオ実行中にリング全周の同一車線ペアを十分な数だけ検査している', () => {
+    // 検出力そのものの回帰ガード。実測(10シード×300秒、10ステップおき)では
+    // 約 77.5 万ペアを検査しており、旧方式の約 7.8 万ペア(真のペアの約 10%)から
+    // 一桁増えた。将来この数が旧方式の水準まで落ちたら検査の穴が再発している
+    const pairs = getResults().reduce((sum, result) => sum + result.checkedPairs, 0);
+    expect(pairs, `検査した同一車線ペアが ${pairs} 件しかない(検出力の後退)`).toBeGreaterThan(
+      500_000,
+    );
   });
 });


### PR DESCRIPTION
Closes #53

## 概要

貫通(同一車線内の車体の重なり)検査にあった 3 つの穴を塞ぎ、同一車線の**真の前後ペアを全件**・**リング全周**にわたって検査するようにした。

**そして、この強化により main に実在する貫通が 1 件見つかりました。** Issue #53 本文は「実際には貫通していない、これはバグではなく回帰検出力の穴」としていますが、**現在の main ではこれは成り立ちません**。詳細は下の「main で見つかった実在の貫通」を参照してください。

## 何を直したか

`traffic-simulation.test.ts` の 1 ファイルのみ。既存 describe のセクション構成は変えていません。

### 1. 既存ヘルパーの書き換え(Issue が名指ししている箇所そのもの)

`runScenario` 内にインラインで書かれていた貫通チェックを `checkPenetration(world)` として切り出し、次の 3 点を修正しました。

| 穴 | 旧 | 新 |
| --- | --- | --- |
| 同一車線ペアの取りこぼし | 区間全体の z 昇順配列の**隣接 index** のみ比較。間に他車線の車が 1 台挟まるとそのペアは永久に漏れる | **車線ごとにグルーピング**してから z 昇順に並べ、リング上の隣接ペアを全件比較 |
| 周回の継ぎ目 | 配列の端と端(index 0 と last)を比較しない | **継ぎ目ペアを必ず含める**(z 最小の車の前方 = 一周先の z 最大の車) |
| 距離計算 | `Math.abs(behind.z - ahead.z)` で周回非対応 | `WRAP_LENGTH` による正の剰余。`Vehicle.findAhead` が周回時に使う `this.z - other.z + WRAP_LENGTH` と同じ尺度 |

`wrapDelta`(符号付き最短距離)ではなく**正の剰余**を使っています。`wrapDelta` だと周回しない加速車線(lane 3)の継ぎ目ペアのように半周を超える距離が負へ折り返り、存在しない貫通を誤検出するためです。この点は新規テストで固定しています。

### 2. しきい値

旧: `expect(worstGap).toBeGreaterThan(-1.0)` = 「1m めり込んでも合格」で、貫通防止という目的に対して意味を成していませんでした。
新: **重なり件数 0**(車間 0m = 前後の車体が触れる境界)で判定します。テスト名から `(許容 -1.0m)` を外しました。

失敗時の診断メッセージ(`minGapDetail`、合流 closure のダンプ)は既存のものを維持し、`lane` と `distance` を追加しました。

### 3. 新規セクション `貫通検査のカバレッジ (Issue #53)`

ファイル末尾に追加。上記 3 つの穴それぞれを、意図的に作った配置で固定する単体テスト 4 件 + 検出力そのものの回帰ガード 1 件です。

**回帰ガードの期待値(`DIFF_AVERAGE_MIN = 7` / `DIFF_AVERAGE_MAX = 12`)には触れていません。**

## 検査ペア数・最小車間の変化

10 シード × 300 秒、既存と同じ 10 ステップ(0.5s)おきのサンプリング。

| | 旧方式 | 新方式 |
| --- | --- | --- |
| 検査した同一車線ペア | 78,325 | **774,915** |
| カバレッジ | **10.1%** | 100% |
| 観測した最小車間 | 1.68m | **-1.57m** |
| 検出した重なり | **0 件** | **1 件** |

Issue 記載の「10.3%」をほぼそのまま再現しています(下の再現状況の表を参照)。

毎ステップ検査(EVERY=1)まで細かくすると、同じ貫通の最悪値は **-2.263m** でした。本 PR では実行時間を維持するため既存どおり 10 ステップおきのままにしています(それでもこの貫通は検出できます)。

## main で見つかった実在の貫通

毎ステップ検査した結果、10 シード中 **seed=33 の 1 エピソードのみ**:

```
seed=33 sec=R lane=1 t=57.35..57.85 (11ステップ連続) worstGap=-2.263m 継ぎ目ペア=true
  ahead  #67  z=407.28  v=2.70  直近車線変更=39.25s前 (1->0)
  behind #105 z=-406.38 v=0.00  直近車線変更=0.00s前 (2->1)   ← 変更完了と同時に重なった
```

**原因は Issue #50 そのものです。** `checkLaneSafetyForChange` は

```ts
const deltaZ = Math.abs(other.z - this.z);
if (deltaZ > 90) continue;
```

としており、継ぎ目をまたぐ相手との `|Δz|` は 813m になるため **90m 超として問答無用でスキップ**されます。#105 は 3m 先にいる #67 を一度も見ないまま lane2 → lane1 の車線変更を完了し、その瞬間に 2.26m めり込みました。`fix/50-wrap-lane-safety` は同じ箇所を `wrapDelta` に置き換えており、`|wrapDelta| = 3.03 ≤ 90` となって相手を認識し `danger` を返すため、この車線変更自体が起きなくなります。因果関係は明確で、単なる軌道の揺らぎではありません。

**旧方式は毎ステップ検査しても(784,443 ペア)この貫通を 1 件も検出できません。** Issue が指摘した「継ぎ目こそ盲点」がそのまま現実になっていました。

### 測定バグの可能性の排除

- 車線変更中の車は `occupies()` で隣車線も占有するため、**`laneChange.state !== 'none'` の車は検査対象から除外**しています(旧実装と同じ扱い)。よって「車線変更中の隣車線占有を重なりと誤判定」は起きません。上記の #105 は**車線変更が完了して `state === 'none'` になった後**の観測です。
- `waiting` の車は `rebuildSectionIndex` の時点で `sectionVehicles` から除かれています。
- 周回しない lane 3 の継ぎ目ペアは正の剰余では常に正の大きな距離になり、負にはなりません(専用テストで固定)。
- 車間の計算式はシミュレーション本体の `Vehicle.findAhead` と同一です。つまり**シミュレーション自身の尺度で見ても負の車間**です。

## Issue #53 記載の数値の再現状況

| Issue 記載 | 実測 | 再現 |
| --- | --- | --- |
| 真の前後ペア総数 227,404 (3シード) | 227,698 | ✅ |
| 既存テストの比較ペア数 23,469 (3シード) | 23,570 | ✅ |
| カバレッジ 10.3% | 10.4% (3シード) / 10.1% (10シード) | ✅ |
| 既存が見た最小車間 6.69m | 1.68m (10シード) | ❌ |
| 真の最小車間 5.56m | -1.57m (10シード) | ❌ |
| 厳密検査で重なり 0 件・最小 4.03m | **重なり 1 件・最小 -2.26m** | ❌ |

ペア数(構造的な量)はほぼ完全に再現する一方、車間(分布の裾の統計量)は再現しません。Issue 起票後に #48 系の合流トランザクション実装など多数の変更が main に入っており、その間に貫通が入り込んだものと考えられます。**「実際には貫通していない」という Issue の結論は、現在の main には当てはまりません。**

## fix/50-wrap-lane-safety に当てた結果

`fix/50` の `src/core/vehicle.ts` は本 PR の base(現 main)と `vehicle.ts` が完全に同一のコミットから分岐しているため、`vehicle.ts` だけを差し替えれば「main + #50 の修正」を正確に再現できます(両者の差分は index.html / style.css のみ)。同一シード・同一条件で比較しました。

| | main | main + fix/50 |
| --- | --- | --- |
| 重なり(10ステップおき) | **1 件** / 最小 -1.57m | **0 件** / 最小 1.42m |
| 重なり(毎ステップ) | **11 観測 = 1 エピソード** / 最悪 -2.26m | **0 件** / 最小 1.41m |

本 PR の強化テスト一式を `main + fix/50` に対して流したところ、**貫通防止テストは PASS** しました。

なお `main + fix/50` では貫通とは無関係な既存テストが 3 件落ちます(`10シード平均のスコア差が 7〜12 に収まる` が平均差 3.7、`加速復帰`、`流入・流出と滞留`)。これは #91 側の課題であり本 PR とは独立です。#91 が Draft のままである理由もここにあると思われます。

## テスト実行時間

| | 実行時間 |
| --- | --- |
| 変更前 (main, 161 tests) | 154.50s |
| 変更後 (166 tests) | 132.16s / 400.73s |

計算量は車線ごとのソートで **O(N log N)** に収まっており、素朴な O(n²) にはしていません(検査そのものは既存と同じ 10 ステップおきのままで、回数も増やしていません)。

ただし**実行時間の測定値は信用しないでください**。計測環境で多数のエージェントが並行実行されており、変更後の同一コードが 132.16s と 400.73s という開きを見せました。系統的な増加は観測されていませんが、この環境では有意な比較ができません。判断は上記の計算量にもとづいてください。

## CI が赤いことについて / マージ順序

**この PR は main に対して意図的に赤くなります。** `衝突回避・貫通防止 > 長時間運転しても同一車線内で車両が重ならない` が 1 件失敗し、165 passed / 1 failed です。これは**テストが正しく実在のバグを検出している**状態であり、テストを緩めて通すべきではないと判断しました。

- **#91 (Issue #50 の修正) のマージが前提です。** #91 がマージされれば本 PR は緑になります。
- そのため **Draft** にしています。
- base は `main` のままにしました。理由は (1) 本 PR の差分をテスト 1 ファイルに限定でき、#50 のコード変更を巻き込まないため、(2) #91 自身がまだ Draft で今後変わりうるブランチにスタックさせると、そちらの rebase に巻き込まれるためです。

## 車線変更中の車の扱い

`occupies()` のとおり車線変更中の車は 2 車線にまたがり「どちらの車線に居るか」が定まりません。重なりの定義が曖昧になり、車線変更のたびに偽陽性が出るため、**`laneChange.state !== 'none'` の車は検査対象から除外**しました(旧実装と同じ方針を維持)。この判断は `貫通検査のカバレッジ (Issue #53)` の専用テストで固定しています。

その代わり、**車線変更が完了した直後の状態は検査対象になります**。今回 main で見つかった貫通はまさにそのケースで、この扱いだからこそ検出できました。

## 補足

同一 Issue に対する古いブランチ `test/53-penetration-coverage` が remote に残っています(旧 main ベース、PR なし)。本 PR に完全に置き換えられているため、削除して問題ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBRGuQ4Doy7RW3UFLPc9ae
