### PR TITLE
fix: viewport のズーム禁止を外し title を OGP に揃える (#104)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,8 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
-    <title>6車線比較 渋滞シミュレーション</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>「追いつかれた車両の義務」で渋滞は本当に減るのか？</title>
     <meta
       name="description"
       content="「追いつかれた車両の義務」がある道路とない道路を並べて走らせ、ルール1つの有無が渋滞のできかたに与える差を観察できる3D渋滞シミュレーション。"

--- a/src/style.css
+++ b/src/style.css
@@ -67,7 +67,7 @@ body {
   position: fixed;
   inset: 0;
 }
-canvas {
+#container > canvas {
   display: block;
   touch-action: none;
 }


### PR DESCRIPTION
## 概要

`index.html` の viewport に入っていた `maximum-scale=1.0, user-scalable=no` は、ページ全体の拡大縮小を禁止するため **WCAG 1.4.4 (Resize text)** に抵触していた。`about.html` は既に `width=device-width, initial-scale=1.0` のみで、index 側だけが逸脱していた。あわせて `<title>` を OGP タイトルに揃えた。

## 変更内容

- `index.html`: viewport から `maximum-scale=1.0, user-scalable=no` を削除
- `index.html`: `<title>` を「6車線比較 渋滞シミュレーション」→「「追いつかれた車両の義務」で渋滞は本当に減るのか？」（`og:title` と一致）に変更
- `src/style.css`: `touch-action: none` の適用対象を `canvas` 全体から `#container > canvas` に限定

## ピンチ操作の切り分け

viewport のズーム禁止を外すとキャンバス上のピンチがページズームを誘発しうるため、`touch-action: none` を 3D キャンバスだけに限定した。

- **キャンバス上**: `touch-action: none` によりブラウザのピンチズームが抑止され、`src/render/camera.ts` の pointer イベントによるカメラズームがそのまま働く
- **キャンバス外**（HUD・パラメータパネル・ページ本体）: ブラウザのピンチズームが有効になる

`camera.ts:435` の `preventDefault()` はキャンバス要素（`dom`）にバインドされており document 全体には及ばないため、この切り分けで意図どおりに動作する。

## 影響範囲

`index.html` (+2/-5), `src/style.css` (+1/-1)。シミュレーションのロジックには一切触れていない。

## 確認してほしい点

実機のタッチデバイスでのピンチ操作（キャンバス上＝カメラズーム / キャンバス外＝ページズーム）は目視確認をお願いしたい。

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sb6PHckdhPF1vvn1Bfb5gk