### PR TITLE
ci: Node と pnpm のセットアップを mise-action に統一 (#119)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # package.json の packageManager からバージョンを読む
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: jdx/mise-action@v4
+      - name: Resolve pnpm store path
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          node-version-file: .node-version
-          cache: pnpm
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Format, lint and type check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 
 - ランタイムは **Node.js**（版数は `.node-version` / `package.json#devEngines` 参照）。
 - パッケージマネージャは **pnpm**（版数は `package.json#packageManager` 参照）。
+- Node / pnpm の導入は **mise**（`mise.toml`）に集約。ローカルは `mise install`、CI は `jdx/mise-action` が同じ設定を読む。Node の版数は `.node-version` が単一の情報源で、pnpm の版数は `mise.toml` に `package.json#packageManager` と同じ値を書く（両方を更新すること）。
 - ツールチェーンは **Vite+（`vp`）** に統一（ビルド=Vite / テスト=Vitest / lint=Oxlint / フォーマット=Oxfmt / 型チェック）。設定は `vite.config.ts` に集約。
 
 | コマンド                    | 内容                                                                                   |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 - ランタイム: Node.js 26 (`.node-version` で固定)
 - パッケージマネージャ: pnpm (`package.json#packageManager` で固定)
+- ツール導入: [mise](https://mise.jdx.dev/) (`mise.toml`)。`mise install` で Node (`.node-version`) と pnpm が揃う。
+  CI も同じ設定を `jdx/mise-action` 経由で使う
 - ツールチェーン: [Vite+](https://viteplus.dev/) (`vp`) に統一。
   ビルド (Vite) / テスト (Vitest) / lint (Oxlint) / フォーマット (Oxfmt) / 型チェックがすべて `vp` 経由で動く
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+[settings]
+# Node の版数は .node-version を情報源にする（package.json#devEngines は範囲指定なので使わない）
+idiomatic_version_file_enable_tools = ["node"]
+idiomatic_version_file_disable_files = ["node:package.json"]
+
+[tools]
+pnpm = "11.13.0"


### PR DESCRIPTION
actions/setup-node と pnpm/action-setup をやめ、jdx/mise-action で
Node と pnpm をまとめて導入するようにした。

- mise.toml を追加。Node のバージョンは .node-version を単一の情報源とし、
  範囲指定の package.json#devEngines は解決に使わない設定にした
- pnpm は mise.toml で package.json#packageManager と同じ版数を固定
- setup-node の cache: pnpm が無くなるため、pnpm store のキャッシュを
  actions/cache で明示的に維持
- README / AGENTS.md にツール導入の記述を追加

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y9PfEi5w8io1gijLvYGL3t