### PR TITLE
DI機構を導入する (#120)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,12 @@
 ## E. コード・コミット規約
 
 - **コメント・コミットメッセージは日本語**で書く。
+
+### 依存注入 (DI) の規約 (Issue #120)
+
+- DI ライブラリは導入しない。**依存はコンストラクタ／生成関数の末尾引数で受け取り、既定値（デフォルト引数）で初期化**する。
+- 実体の生成は **`src/core/factory.ts`（初期化用関数を集めた合成ルート）に集約**する。`createVehicleDeps()` / `createWorldDeps()` / `createVehicle()` がそれ。
+- **import cycle 防止:** 依存される側（`vehicle.ts` / `world.ts`）は相手の実体を値 import してはならない（**型 import のみ**）。実体への値 import は `factory.ts` だけが持つ。逆に `factory.ts` は、自分を値 import しているモジュール（`world.ts`）を値 import してはならない。
+  - 値 import の向き: `factory.ts` → `vehicle.ts` / 各 controller、`world.ts` → `factory.ts`。
+- `World` は `deps.createVehicle` 経由で車両を作り（`World#createVehicle`）、`Vehicle` は注入された `VehicleDeps` からコントローラを **1台につき1組だけ**生成して保持する（コントローラは状態を持たない委譲先なので挙動は変わらない）。
+- 依存の差し替えはテスト専用の抜け道ではあるが、**差し替えで L/R の挙動差を作ってはならない**（A の不変条件が優先）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,5 +73,6 @@
 - 実体の生成は **`src/core/factory.ts`（初期化用関数を集めた合成ルート）に集約**する。`createVehicleDeps()` / `createWorldDeps()` / `createVehicle()` がそれ。
 - **import cycle 防止:** 依存される側（`vehicle.ts` / `world.ts`）は相手の実体を値 import してはならない（**型 import のみ**）。実体への値 import は `factory.ts` だけが持つ。逆に `factory.ts` は、自分を値 import しているモジュール（`world.ts`）を値 import してはならない。
   - 値 import の向き: `factory.ts` → `vehicle.ts` / 各 controller、`world.ts` → `factory.ts`。
-- `World` は `deps.createVehicle` 経由で車両を作り（`World#createVehicle`）、`Vehicle` は注入された `VehicleDeps` からコントローラを **1台につき1組だけ**生成して保持する（コントローラは状態を持たない委譲先なので挙動は変わらない）。
+- `World` は `deps.createVehicle` 経由で車両を作り（`World#createVehicle`）、その際 **車両側の依存 `vehicleDeps` も明示的に渡す**（生成関数だけを差し替えた時に `vehicleDeps` の差し替えが黙って無視されるのを防ぐ）。既定値は `Vehicle` のデフォルト引数の一箇所だけに置く。
+- `Vehicle` は注入された `VehicleDeps` からコントローラを **1台につき1組だけ**生成して保持する（状態を持たない委譲先なので挙動は変わらない）。生成時に車両状態を読んでも安全なよう、**コンストラクタ末尾**で作る。
 - 依存の差し替えはテスト専用の抜け道ではあるが、**差し替えで L/R の挙動差を作ってはならない**（A の不変条件が優先）。

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -30,7 +30,10 @@ export function createVehicleDeps(overrides: Partial<VehicleDeps> = {}): Vehicle
   };
 }
 
-/** 既定の車両生成。deps 省略時は生成元 World が持つ車両依存を使う。 */
+/**
+ * 既定の車両生成。deps は素通しで渡し、省略時の既定値は Vehicle 側の
+ * デフォルト引数 (= 生成元 World の車両依存) の一箇所に委ねる。
+ */
 export const createVehicle: VehicleFactory = (
   world,
   section,
@@ -38,7 +41,7 @@ export const createVehicle: VehicleFactory = (
   z,
   typeName,
   desiredSpeed,
-  deps = world.vehicleDeps,
+  deps,
 ) => new Vehicle(world, section, lane, z, typeName, desiredSpeed, deps);
 
 /**

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -1,0 +1,54 @@
+/* ============================================================
+   シミュレーションコアの依存初期化（合成ルート）
+   （DOM / THREE 非依存・テスト対象）
+
+   Vehicle / World は協調相手の実体をここ経由で受け取る。
+   各モジュールから実体への import をこのモジュールへ集約することで、
+   vehicle → controller / world → vehicle の import cycle を作らずに
+   依存を差し替え可能にする（Issue #120）。
+
+   ここは実体を import する側なので、逆向き（world.ts など）から値として
+   import されるモジュールを値 import してはならない（型 import のみ可）。
+   ============================================================ */
+import { LaneChangeController } from './lane-change-controller';
+import { LongitudinalController } from './longitudinal-controller';
+import { MergeCoordinator } from './merge-coordinator';
+import { Vehicle } from './vehicle';
+import type { VehicleDeps, VehicleFactory } from './vehicle';
+import type { WorldDeps } from './world';
+
+/**
+ * 車両が使うコントローラ群の初期化。
+ * overrides に渡した依存だけを差し替える（テストでは偽物を注入できる）。
+ */
+export function createVehicleDeps(overrides: Partial<VehicleDeps> = {}): VehicleDeps {
+  return {
+    createLaneChangeController: (vehicle) => new LaneChangeController(vehicle),
+    createLongitudinalController: (vehicle) => new LongitudinalController(vehicle),
+    createMergeCoordinator: (vehicle) => new MergeCoordinator(vehicle),
+    ...overrides,
+  };
+}
+
+/** 既定の車両生成。deps 省略時は生成元 World が持つ車両依存を使う。 */
+export const createVehicle: VehicleFactory = (
+  world,
+  section,
+  lane,
+  z,
+  typeName,
+  desiredSpeed,
+  deps = world.vehicleDeps,
+) => new Vehicle(world, section, lane, z, typeName, desiredSpeed, deps);
+
+/**
+ * World が持つ依存の初期化。
+ * overrides に渡した依存だけを差し替える（車両生成そのものを偽物にもできる）。
+ */
+export function createWorldDeps(overrides: Partial<WorldDeps> = {}): WorldDeps {
+  return {
+    createVehicle,
+    vehicleDeps: createVehicleDeps(),
+    ...overrides,
+  };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -22,7 +22,17 @@ export type {
 } from './constants';
 export { clamp, lerp, smooth, createRng, WRAP_LENGTH, wrapDelta } from './utils';
 export type { Rng } from './utils';
-export { Vehicle, mergeCongestion, nextArrivalDistance, smoothstepRange } from './vehicle';
+// 依存の初期化(DI)はこのモジュール経由で行う (Issue #120)
+export { createVehicle, createVehicleDeps, createWorldDeps } from './factory';
+export { LaneChangeController } from './lane-change-controller';
+export { LongitudinalController } from './longitudinal-controller';
+export {
+  mergeCongestion,
+  MergeCoordinator,
+  nextArrivalDistance,
+  smoothstepRange,
+} from './merge-coordinator';
+export { Vehicle } from './vehicle';
 export {
   buildMergeDependencyClosure,
   isMergeTransactionAdmissible,
@@ -52,8 +62,10 @@ export type {
   ProjectedMergeSlot,
   SpeedEnvelope,
   ReservedMotion,
+  VehicleDeps,
+  VehicleFactory,
   VehicleSnapshot,
   WorldSnapshot,
 } from './vehicle';
 export { World } from './world';
-export type { WorldOptions, SectionStats, SmoothTime } from './world';
+export type { WorldDeps, WorldOptions, SectionStats, SmoothTime } from './world';

--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -169,8 +169,7 @@ export type VehicleFactory = (
 
 export class Vehicle {
   world: World;
-  /** 判断を委譲するコントローラ群 (生成時に注入され、以降は差し替えない) */
-  readonly deps: VehicleDeps;
+  /** 判断の委譲先。生成時に注入され、以降は差し替えない (Issue #120) */
   readonly laneChangeController: LaneChangeController;
   readonly longitudinalController: LongitudinalController;
   readonly mergeCoordinator: MergeCoordinator;
@@ -244,14 +243,9 @@ export class Vehicle {
     z: number,
     typeName: VehicleTypeName,
     desiredSpeed: number,
-    deps: VehicleDeps = world.vehicleDeps,
+    deps: VehicleDeps = world.deps.vehicleDeps,
   ) {
     this.world = world;
-    // コントローラは状態を持たない薄い委譲先なので、1台につき1組だけ作る
-    this.deps = deps;
-    this.laneChangeController = deps.createLaneChangeController(this);
-    this.longitudinalController = deps.createLongitudinalController(this);
-    this.mergeCoordinator = deps.createMergeCoordinator(this);
     this.spawnOrder = world.nextVehicleOrder++;
     this.section = section; // 'L' = 義務あり / 'R' = 義務なし
     this.lane = lane; // 0 = 追い越し車線(進行方向の右端)
@@ -358,6 +352,12 @@ export class Vehicle {
     this.laneChangeAversion = 0.7 + random() * 0.6; // 車線変更への腰の重さ(個人差)
     this.slowAheadTimer = 0; // 遅い車に抑え込まれている時間
     this.noiseAmplitude = 0.5 + random() * 0.7; // 揺らぎの大きさの個人差
+
+    // コントローラは状態を持たない委譲先なので、1台につき1組だけ作る。
+    // 生成時に車両の状態を読んでも安全なよう、初期化を終えてから作る
+    this.laneChangeController = deps.createLaneChangeController(this);
+    this.longitudinalController = deps.createLongitudinalController(this);
+    this.mergeCoordinator = deps.createMergeCoordinator(this);
   }
 
   occupies(lane: number): boolean {

--- a/src/core/vehicle.ts
+++ b/src/core/vehicle.ts
@@ -4,10 +4,9 @@
    ============================================================ */
 import { CONST, TYPES } from './constants';
 import type { Section, VehicleTypeName, VehicleTypeSpec } from './constants';
-import { LaneChangeController } from './lane-change-controller';
-import { LongitudinalController } from './longitudinal-controller';
-import { MergeCoordinator } from './merge-coordinator';
-export { mergeCongestion, nextArrivalDistance, smoothstepRange } from './merge-coordinator';
+import type { LaneChangeController } from './lane-change-controller';
+import type { LongitudinalController } from './longitudinal-controller';
+import type { MergeCoordinator } from './merge-coordinator';
 import { clamp, lerp, smooth, WRAP_LENGTH } from './utils';
 import type { World } from './world';
 
@@ -146,8 +145,35 @@ export interface ProjectedMergeSlot {
   rampEta: number;
 }
 
+/**
+ * 車両が判断を委譲するコントローラ群の初期化関数 (Issue #120)。
+ * 実体は初期化用モジュール (factory.ts) が供給するため、
+ * ここからコントローラ実装への値 import は持たない (import cycle 防止)。
+ */
+export interface VehicleDeps {
+  readonly createLaneChangeController: (vehicle: Vehicle) => LaneChangeController;
+  readonly createLongitudinalController: (vehicle: Vehicle) => LongitudinalController;
+  readonly createMergeCoordinator: (vehicle: Vehicle) => MergeCoordinator;
+}
+
+/** 車両の生成関数。World は実体を直接 new せずこれを介して車両を作る。 */
+export type VehicleFactory = (
+  world: World,
+  section: Section,
+  lane: number,
+  z: number,
+  typeName: VehicleTypeName,
+  desiredSpeed: number,
+  deps?: VehicleDeps,
+) => Vehicle;
+
 export class Vehicle {
   world: World;
+  /** 判断を委譲するコントローラ群 (生成時に注入され、以降は差し替えない) */
+  readonly deps: VehicleDeps;
+  readonly laneChangeController: LaneChangeController;
+  readonly longitudinalController: LongitudinalController;
+  readonly mergeCoordinator: MergeCoordinator;
   spawnOrder: number;
   section: Section;
   lane: number;
@@ -218,8 +244,14 @@ export class Vehicle {
     z: number,
     typeName: VehicleTypeName,
     desiredSpeed: number,
+    deps: VehicleDeps = world.vehicleDeps,
   ) {
     this.world = world;
+    // コントローラは状態を持たない薄い委譲先なので、1台につき1組だけ作る
+    this.deps = deps;
+    this.laneChangeController = deps.createLaneChangeController(this);
+    this.longitudinalController = deps.createLongitudinalController(this);
+    this.mergeCoordinator = deps.createMergeCoordinator(this);
     this.spawnOrder = world.nextVehicleOrder++;
     this.section = section; // 'L' = 義務あり / 'R' = 義務なし
     this.lane = lane; // 0 = 追い越し車線(進行方向の右端)
@@ -396,11 +428,11 @@ export class Vehicle {
   }
 
   mergeHeadways(congestion: number): { front: number; rear: number } {
-    return new MergeCoordinator(this).mergeHeadways(congestion);
+    return this.mergeCoordinator.mergeHeadways(congestion);
   }
 
   evaluateEntryCertificate(snapshot: WorldSnapshot, deltaTime = 1 / 20): MergeCertificate | null {
-    return new MergeCoordinator(this).evaluateEntryCertificate(snapshot, deltaTime);
+    return this.mergeCoordinator.evaluateEntryCertificate(snapshot, deltaTime);
   }
 
   projectReservation(
@@ -408,23 +440,23 @@ export class Vehicle {
     plan: MergePlan,
     deltaTime: number,
   ): MergeDirective | null {
-    return new MergeCoordinator(this).projectReservation(snapshot, plan, deltaTime);
+    return this.mergeCoordinator.projectReservation(snapshot, plan, deltaTime);
   }
 
   projectMergeSlot(rampEta: number): ProjectedMergeSlot | null {
-    return new MergeCoordinator(this).projectMergeSlot(rampEta);
+    return this.mergeCoordinator.projectMergeSlot(rampEta);
   }
 
   projectReservedMergeSlot(plan: MergePlan): ProjectedMergeSlot | null {
-    return new MergeCoordinator(this).projectReservedMergeSlot(plan);
+    return this.mergeCoordinator.projectReservedMergeSlot(plan);
   }
 
   isProjectedSlotSafe(slot: ProjectedMergeSlot, congestion: number): boolean {
-    return new MergeCoordinator(this).isProjectedSlotSafe(slot, congestion);
+    return this.mergeCoordinator.isProjectedSlotSafe(slot, congestion);
   }
 
   projectMergeCongestionSample(slot: ProjectedMergeSlot | null): number {
-    return new MergeCoordinator(this).projectMergeCongestionSample(slot);
+    return this.mergeCoordinator.projectMergeCongestionSample(slot);
   }
 
   projectMergeCongestion(
@@ -432,23 +464,23 @@ export class Vehicle {
     deltaTime: number,
     sample = this.projectMergeCongestionSample(slot),
   ): number {
-    return new MergeCoordinator(this).projectMergeCongestion(slot, deltaTime, sample);
+    return this.mergeCoordinator.projectMergeCongestion(slot, deltaTime, sample);
   }
 
   estimateMergeEta(): number {
-    return new MergeCoordinator(this).estimateMergeEta();
+    return this.mergeCoordinator.estimateMergeEta();
   }
 
   latestMergeCommitZ(): number {
-    return new MergeCoordinator(this).latestMergeCommitZ();
+    return this.mergeCoordinator.latestMergeCommitZ();
   }
 
   evaluateMergePlan(deltaTime: number, lastSource: MergeSource | null): MergePlan {
-    return new MergeCoordinator(this).evaluateMergePlan(deltaTime, lastSource);
+    return this.mergeCoordinator.evaluateMergePlan(deltaTime, lastSource);
   }
 
   isMergeApplySafe(plan: MergePlan): boolean {
-    return new MergeCoordinator(this).isMergeApplySafe(plan);
+    return this.mergeCoordinator.isMergeApplySafe(plan);
   }
 
   applyMergePlan(plan: MergePlan): void {
@@ -540,19 +572,19 @@ export class Vehicle {
 
   // 隣車線にほぼ同速で並走する車両がいるか(車線変更を物理的に塞ぐ「象レース」検知)
   hasDeadlockAlongside(lane: number): boolean {
-    return new LaneChangeController(this).hasDeadlockAlongside(lane);
+    return this.laneChangeController.hasDeadlockAlongside(lane);
   }
 
   // 復帰先車線で自分の真横(±車体+8m)を占有し、車線変更を物理的に塞ぐ並走車を返す
   findAlongside(lane: number): Vehicle | null {
-    return new LaneChangeController(this).findAlongside(lane);
+    return this.laneChangeController.findAlongside(lane);
   }
 
   // 加速復帰の開始判定: 追い越し車線で後続に追いつかれ、復帰先(レーン1)が並走車に
   // 塞がれている時、「速度差が小さく、並走車の前方が空いていて前に出れば戻れる
   // 見込みがある」なら一時的に加速して並走車を抜き、車線復帰を狙う
   tryStartReturnBoost(ahead: NeighborInfo | null): boolean {
-    return new LaneChangeController(this).tryStartReturnBoost(ahead);
+    return this.laneChangeController.tryStartReturnBoost(ahead);
   }
 
   /**
@@ -595,23 +627,23 @@ export class Vehicle {
   // 車線変更先の安全確認: 'safe' | 'hold' | 'danger'
   // 左方向(譲り・キープレフト)は遅い車線へ移るため、要求マージンをやや緩和する
   checkLaneSafetyForChange(toLane: number): 'safe' | 'hold' | 'danger' {
-    return new LaneChangeController(this).checkLaneSafetyForChange(toLane);
+    return this.laneChangeController.checkLaneSafetyForChange(toLane);
   }
 
   tryLaneChange(toLane: number): boolean {
-    return new LaneChangeController(this).tryLaneChange(toLane);
+    return this.laneChangeController.tryLaneChange(toLane);
   }
 
   cancelLaneChange(): void {
-    return new LaneChangeController(this).cancelLaneChange();
+    return this.laneChangeController.cancelLaneChange();
   }
 
   updateLaneChange(deltaTime: number): void {
-    return new LaneChangeController(this).updateLaneChange(deltaTime);
+    return this.laneChangeController.updateLaneChange(deltaTime);
   }
 
   decide(ahead: NeighborInfo | null, deltaTime: number): void {
-    return new LaneChangeController(this).decide(ahead, deltaTime);
+    return this.laneChangeController.decide(ahead, deltaTime);
   }
 
   update(deltaTime: number): void {
@@ -631,15 +663,14 @@ export class Vehicle {
     }
     this.updateLaneChange(deltaTime);
 
-    const longitudinalController = new LongitudinalController(this);
-    const ahead = longitudinalController.update(deltaTime);
+    const ahead = this.longitudinalController.update(deltaTime);
     this.z -= this.speed * deltaTime;
 
     // --- 意思決定 ---
     if (this.laneChange.state === 'none' && this.laneChangeCooldown <= 0)
       this.decide(ahead, deltaTime);
 
-    longitudinalController.updateHazard(deltaTime);
+    this.longitudinalController.updateHazard(deltaTime);
 
     // --- 終端処理 ---
     // rulesモード: 終端 = 出口。一定割合の車がここで流出する(捌けた分だけ出る)。

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -6,12 +6,12 @@ import { CONST, rampBodyIntersectsGore, sectionTrackX, TYPES, TYPE_WEIGHTS } fro
 import type { Section, SimMode, VehicleTypeName } from './constants';
 import { clamp, wrapDelta, WRAP_LENGTH } from './utils';
 import type { Rng } from './utils';
+import { createWorldDeps } from './factory';
 import {
   isMergeTransactionAdmissible,
   MergeTransactionPlanningError,
   planMergeTransaction,
 } from './merge-transaction';
-import { Vehicle } from './vehicle';
 import type {
   MergeCandidate,
   MergeCertificate,
@@ -20,6 +20,9 @@ import type {
   MergeSource,
   MergeTransaction,
   ReservedMotion,
+  Vehicle,
+  VehicleDeps,
+  VehicleFactory,
   VehicleSnapshot,
   WorldSnapshot,
 } from './vehicle';
@@ -28,6 +31,18 @@ export interface WorldOptions {
   rng?: Rng;
   mode?: SimMode;
   spawnInterval?: number;
+}
+
+/**
+ * World が使う依存 (Issue #120)。
+ * 実体は初期化用モジュール (factory.ts) が供給するため、
+ * ここから Vehicle 実装への値 import は持たない (import cycle 防止)。
+ */
+export interface WorldDeps {
+  /** 車両の生成。テストでは偽物の車両生成へ差し替えられる。 */
+  readonly createVehicle: VehicleFactory;
+  /** 生成した車両へ引き継ぐコントローラ群の初期化。 */
+  readonly vehicleDeps: VehicleDeps;
 }
 
 export interface SectionStats {
@@ -44,6 +59,10 @@ export interface SmoothTime {
 }
 
 export class World {
+  /** 生成時に注入された依存 (以降は差し替えない) */
+  readonly deps: WorldDeps;
+  /** この World が作る車両へ渡すコントローラ群の初期化 */
+  readonly vehicleDeps: VehicleDeps;
   rng: Rng;
   mode: SimMode;
   spawnInterval: number;
@@ -66,7 +85,9 @@ export class World {
   laneRoundRobin = 0; // absorbモード: レーン割当のラウンドロビン
   perturbTimer: number | null = null; // absorbモード: 次のよそ見ブレーキまでの残り時間
 
-  constructor(options: WorldOptions = {}) {
+  constructor(options: WorldOptions = {}, deps: WorldDeps = createWorldDeps()) {
+    this.deps = deps;
+    this.vehicleDeps = deps.vehicleDeps;
     this.rng = options.rng || Math.random;
     this.mode = options.mode || 'rules'; // 'rules' = ルール比較 / 'absorb' = 渋滞吸収運転
     this.spawnInterval = options.spawnInterval != null ? options.spawnInterval : 800;
@@ -82,6 +103,17 @@ export class World {
       outflow: { L: 0, R: 0 },
     };
     this.smoothTime = { L: 0, R: 0, draw: 0 };
+  }
+
+  /** 車両を生成する。実体の選択は注入された依存に委ねる (Issue #120)。 */
+  createVehicle(
+    section: Section,
+    lane: number,
+    z: number,
+    typeName: VehicleTypeName,
+    desiredSpeed: number,
+  ): Vehicle {
+    return this.deps.createVehicle(this, section, lane, z, typeName, desiredSpeed);
   }
 
   pickType(): VehicleTypeName {
@@ -216,8 +248,8 @@ export class World {
       const z = CONST.ROAD_HALF + spec.length;
       if (!this.isSpawnClear('L', lane, z, null) || !this.isSpawnClear('R', lane, z, null))
         return false;
-      const vehicleL = new Vehicle(this, 'L', lane, z, typeName, speed);
-      const vehicleR = new Vehicle(this, 'R', lane, z, typeName, speed);
+      const vehicleL = this.createVehicle('L', lane, z, typeName, speed);
+      const vehicleR = this.createVehicle('R', lane, z, typeName, speed);
       vehicleL.speed = this.safeSpawnSpeed('L', lane, z, vehicleL.length, vehicleL.speed, null);
       vehicleR.speed = this.safeSpawnSpeed('R', lane, z, vehicleR.length, vehicleR.speed, null);
       this.vehicles.push(vehicleL, vehicleR);
@@ -248,8 +280,7 @@ export class World {
       // ランプ需要は入口の lane 3 が空いていても、lane 2 の将来枠を証明するまで
       // 有効道路状態へ入れない。本線需要は従来通り入口判定だけで扱う。
       const lane = viaRamp ? null : this.admissibleLane(section, lanes, z);
-      const vehicle = new Vehicle(
-        this,
+      const vehicle = this.createVehicle(
         section,
         lane != null ? lane : preferredLane,
         z,
@@ -749,8 +780,8 @@ export class World {
             : Math.floor(this.rng() * 3);
         const laneR = this.mode === 'absorb' ? laneL : Math.floor(this.rng() * 3);
         if (this.isSpawnClear('L', laneL, z, null) && this.isSpawnClear('R', laneR, z, null)) {
-          this.vehicles.push(new Vehicle(this, 'L', laneL, z, typeName, speed));
-          this.vehicles.push(new Vehicle(this, 'R', laneR, z, typeName, speed));
+          this.vehicles.push(this.createVehicle('L', laneL, z, typeName, speed));
+          this.vehicles.push(this.createVehicle('R', laneR, z, typeName, speed));
           break;
         }
       }

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -61,8 +61,6 @@ export interface SmoothTime {
 export class World {
   /** 生成時に注入された依存 (以降は差し替えない) */
   readonly deps: WorldDeps;
-  /** この World が作る車両へ渡すコントローラ群の初期化 */
-  readonly vehicleDeps: VehicleDeps;
   rng: Rng;
   mode: SimMode;
   spawnInterval: number;
@@ -87,7 +85,6 @@ export class World {
 
   constructor(options: WorldOptions = {}, deps: WorldDeps = createWorldDeps()) {
     this.deps = deps;
-    this.vehicleDeps = deps.vehicleDeps;
     this.rng = options.rng || Math.random;
     this.mode = options.mode || 'rules'; // 'rules' = ルール比較 / 'absorb' = 渋滞吸収運転
     this.spawnInterval = options.spawnInterval != null ? options.spawnInterval : 800;
@@ -105,7 +102,11 @@ export class World {
     this.smoothTime = { L: 0, R: 0, draw: 0 };
   }
 
-  /** 車両を生成する。実体の選択は注入された依存に委ねる (Issue #120)。 */
+  /**
+   * 車両を生成する。実体の選択は注入された依存に委ねる (Issue #120)。
+   * 車両側の依存も明示的に渡し、生成関数を差し替えても
+   * vehicleDeps の差し替えが黙って無視されないようにする。
+   */
   createVehicle(
     section: Section,
     lane: number,
@@ -113,7 +114,15 @@ export class World {
     typeName: VehicleTypeName,
     desiredSpeed: number,
   ): Vehicle {
-    return this.deps.createVehicle(this, section, lane, z, typeName, desiredSpeed);
+    return this.deps.createVehicle(
+      this,
+      section,
+      lane,
+      z,
+      typeName,
+      desiredSpeed,
+      this.deps.vehicleDeps,
+    );
   }
 
   pickType(): VehicleTypeName {

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -19,9 +19,9 @@ import {
   createVehicle,
   createVehicleDeps,
   createWorldDeps,
+  isMergeTransactionAdmissible,
   LaneChangeController,
   LongitudinalController,
-  isMergeTransactionAdmissible,
   mergeCongestion,
   MergeCoordinator,
   nextArrivalDistance,
@@ -3624,8 +3624,6 @@ describe('依存注入 (Issue #120)', () => {
     expect(vehicle.laneChangeController).toBeInstanceOf(LaneChangeController);
     expect(vehicle.longitudinalController).toBeInstanceOf(LongitudinalController);
     expect(vehicle.mergeCoordinator).toBeInstanceOf(MergeCoordinator);
-    // World の既定依存は生成した車両へそのまま引き継がれる
-    expect(vehicle.deps).toBe(world.vehicleDeps);
   });
 
   test('コントローラは車両ごとに1組だけ作られ、呼び出しごとに作り直さない', () => {
@@ -3668,6 +3666,8 @@ describe('依存注入 (Issue #120)', () => {
     const created: string[] = [];
     const deps = createWorldDeps({
       createVehicle: (world, section, lane, z, typeName, desiredSpeed, vehicleDeps) => {
+        // World は車両側の依存を明示的に渡してくる(暗黙のフォールバック頼みにしない)
+        expect(vehicleDeps).toBe(world.deps.vehicleDeps);
         created.push(`${section}:${lane}`);
         return createVehicle(world, section, lane, z, typeName, desiredSpeed, vehicleDeps);
       },
@@ -3693,7 +3693,12 @@ describe('依存注入 (Issue #120)', () => {
     );
     const vehicle = world.createVehicle('L', 3, CONST.RAMP_Z_TOP, 'Sedan', 24);
     expect(vehicle.estimateMergeEta()).toBe(42);
+    // 差し替えていない依存は既定の実体のまま
     expect(vehicle.laneChangeController).toBeInstanceOf(LaneChangeController);
+    // World が自分で作る車両にも同じ依存が渡る
+    world.populateInitial();
+    expect(world.vehicles.length).toBeGreaterThan(0);
+    for (const spawned of world.vehicles) expect(spawned.estimateMergeEta()).toBe(42);
   });
 
   test('依存注入はシミュレーション結果を変えない（既定依存の明示指定と同一）', () => {

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -16,8 +16,14 @@ import {
   buildMergeDependencyClosure,
   CONST,
   createRng,
+  createVehicle,
+  createVehicleDeps,
+  createWorldDeps,
+  LaneChangeController,
+  LongitudinalController,
   isMergeTransactionAdmissible,
   mergeCongestion,
+  MergeCoordinator,
   nextArrivalDistance,
   planMergeTransaction,
   RAMP_GEOMETRY,
@@ -3605,5 +3611,100 @@ describe('前方車探索の並べ替え耐性 (Issue #52)', () => {
         if (expectedBehind) expect(actualBehind!.gap).toBeCloseTo(expectedBehind.gap, 9);
       }
     }
+  });
+});
+
+/* ============================================================
+   依存注入 (Issue #120)
+   ============================================================ */
+describe('依存注入 (Issue #120)', () => {
+  test('既定の依存で実体のコントローラが注入される', () => {
+    const world = new World({ rng: createRng(120), spawnInterval: 1e9 });
+    const vehicle = new Vehicle(world, 'L', 1, 0, 'Sedan', 25);
+    expect(vehicle.laneChangeController).toBeInstanceOf(LaneChangeController);
+    expect(vehicle.longitudinalController).toBeInstanceOf(LongitudinalController);
+    expect(vehicle.mergeCoordinator).toBeInstanceOf(MergeCoordinator);
+    // World の既定依存は生成した車両へそのまま引き継がれる
+    expect(vehicle.deps).toBe(world.vehicleDeps);
+  });
+
+  test('コントローラは車両ごとに1組だけ作られ、呼び出しごとに作り直さない', () => {
+    const world = new World({ rng: createRng(121), spawnInterval: 1e9 });
+    const vehicle = new Vehicle(world, 'L', 1, 0, 'Sedan', 25);
+    const laneChangeController = vehicle.laneChangeController;
+    const mergeCoordinator = vehicle.mergeCoordinator;
+    world.rebuildSectionIndex();
+    vehicle.update(1 / 20);
+    vehicle.checkLaneSafetyForChange(2);
+    vehicle.estimateMergeEta();
+    expect(vehicle.laneChangeController).toBe(laneChangeController);
+    expect(vehicle.mergeCoordinator).toBe(mergeCoordinator);
+  });
+
+  test('車両の依存を差し替えると判断の委譲先が入れ替わる', () => {
+    const world = new World({ rng: createRng(122), spawnInterval: 1e9 });
+    const calls: number[] = [];
+    const deps = createVehicleDeps({
+      // 「絶対に車線変更しない」偽コントローラ(他の判断は実体のまま)
+      createLaneChangeController: (vehicle) =>
+        Object.assign(new LaneChangeController(vehicle), {
+          tryLaneChange: (toLane: number) => {
+            calls.push(toLane);
+            return false;
+          },
+        }),
+    });
+    const vehicle = new Vehicle(world, 'L', 1, 0, 'Sedan', 25, deps);
+    world.vehicles.push(vehicle);
+    world.rebuildSectionIndex();
+    expect(vehicle.tryLaneChange(2)).toBe(false);
+    expect(calls).toEqual([2]);
+    // 差し替えていない依存は既定の実体のまま
+    expect(vehicle.mergeCoordinator).toBeInstanceOf(MergeCoordinator);
+    expect(vehicle.laneChange.state).toBe('none');
+  });
+
+  test('World の車両生成を差し替えられる', () => {
+    const created: string[] = [];
+    const deps = createWorldDeps({
+      createVehicle: (world, section, lane, z, typeName, desiredSpeed, vehicleDeps) => {
+        created.push(`${section}:${lane}`);
+        return createVehicle(world, section, lane, z, typeName, desiredSpeed, vehicleDeps);
+      },
+    });
+    const world = new World({ rng: createRng(123), spawnInterval: 1e9 }, deps);
+    world.populateInitial();
+    expect(created.length).toBe(world.vehicles.length);
+    expect(created.length).toBeGreaterThan(0);
+    // 差し替えた生成関数から作られた車両も既定のコントローラを持つ
+    for (const vehicle of world.vehicles)
+      expect(vehicle.laneChangeController).toBeInstanceOf(LaneChangeController);
+  });
+
+  test('World の依存経由で車両のコントローラまで差し替えられる', () => {
+    const world = new World(
+      { rng: createRng(124), spawnInterval: 1e9 },
+      createWorldDeps({
+        vehicleDeps: createVehicleDeps({
+          createMergeCoordinator: (vehicle) =>
+            Object.assign(new MergeCoordinator(vehicle), { estimateMergeEta: () => 42 }),
+        }),
+      }),
+    );
+    const vehicle = world.createVehicle('L', 3, CONST.RAMP_Z_TOP, 'Sedan', 24);
+    expect(vehicle.estimateMergeEta()).toBe(42);
+    expect(vehicle.laneChangeController).toBeInstanceOf(LaneChangeController);
+  });
+
+  test('依存注入はシミュレーション結果を変えない（既定依存の明示指定と同一）', () => {
+    const runSteps = (deps?: ReturnType<typeof createWorldDeps>): number[] => {
+      const world = deps
+        ? new World({ rng: createRng(125), spawnInterval: 800 }, deps)
+        : new World({ rng: createRng(125), spawnInterval: 800 });
+      world.populateInitial();
+      for (let i = 0; i < 200; i++) world.step(1 / 20);
+      return world.vehicles.map((vehicle) => vehicle.z);
+    };
+    expect(runSteps(createWorldDeps())).toEqual(runSteps());
   });
 });


### PR DESCRIPTION
Closes #120

## 概要

テスタビリティと可読性のため、シミュレーションコア（`src/core/`）の依存を注入可能にした。Issue の方針どおり **DI ライブラリは導入せず、末尾引数のデフォルト値で依存を初期化**し、**実体の生成関数は初期化用モジュールに集約**して import cycle を防いでいる。

## 変更内容

### `src/core/factory.ts`（新規・合成ルート）

実体を `new` する箇所をこのモジュールだけに集約した。

- `createVehicleDeps(overrides?)` — 車両が判断を委譲するコントローラ群（`LaneChangeController` / `LongitudinalController` / `MergeCoordinator`）の初期化
- `createVehicle` — 既定の車両生成。`deps` は素通しで渡し、既定値は `Vehicle` 側のデフォルト引数の一箇所に委ねる
- `createWorldDeps(overrides?)` — `World` が使う依存（車両生成・車両依存）の初期化

`overrides` に渡した依存だけを差し替えられるので、テストでは一部だけ偽物にできる。

### import cycle 防止

値 import の向きを一方向に固定した。

- `factory.ts` → `vehicle.ts` / 各 controller（値）
- `world.ts` → `factory.ts`（値）
- `vehicle.ts` / `world.ts` → 相手の実体は**型 import のみ**

これに伴い `vehicle.ts` にあった `merge-coordinator` の再エクスポートを廃止し、`src/core/index.ts` から直接エクスポートするようにした。

### `Vehicle`

- コンストラクタ末尾に `deps: VehicleDeps = world.deps.vehicleDeps` を追加
- コントローラは**1台につき1組だけ**生成して保持（従来は `hasDeadlockAlongside` などの呼び出しごとに `new LaneChangeController(this)` していた）。コントローラは `vehicle` 参照だけを持つ状態なしの委譲先なので、**挙動は変わらない**
- 生成時に車両状態を読んでも安全なよう、コントローラの生成はコンストラクタ末尾（車両の初期化完了後）で行う

### `World`

- コンストラクタに `deps: WorldDeps = createWorldDeps()` を追加
- 車両生成は `World#createVehicle()`（内部で `deps.createVehicle`）に統一し、`new Vehicle(...)` を直接呼ばなくなった
- その際 **車両側の依存 `vehicleDeps` も明示的に渡す**ため、生成関数だけを差し替えても `vehicleDeps` の差し替えが黙って無視されることはない

## テスト

`traffic-simulation.test.ts` 末尾に `describe('依存注入 (Issue #120)')` を追加（6 件）。

- 既定依存で実体のコントローラが注入されること
- コントローラが呼び出しごとに作り直されないこと
- 車両の依存を差し替えると委譲先が入れ替わり、差し替えていない依存は実体のままであること
- `World` の車両生成を差し替えられ、その際 `vehicleDeps` が明示的に渡ること
- `World` の依存経由で、`populateInitial()` が作る車両まで含めてコントローラを差し替えられること
- 既定依存を明示指定しても 200 step 後の全車位置が完全一致すること（挙動不変の確認）

`pnpm check` / `pnpm build` 通過、`pnpm test` は **177 件すべて成功**（既存 171 件 + 新規 6 件）。L/R スコア差の回帰ガード（`DIFF_TARGET = 4`）もそのまま通っている。

## 実験的妥当性への影響

区間依存の分岐は一切追加していない（`section` / `yields` などを読む新規条件はなし）。純粋な配線の変更で、物理・判断ロジックには手を入れていない。AGENTS.md には今回の DI 規約（デフォルト引数方式・値 import の向き・依存の明示的な受け渡し・差し替えで L/R 差を作らないこと）を追記した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Md2kasGFT9WJRDBqd7bovi