### PR TITLE
ci: GitHub Actions を pinact で SHA ピン留めし CI で検証する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Verify GitHub Actions pinning
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: 'false'
+          verify: 'true'
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
       - name: Resolve pnpm store path
         run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
Closes #122

## 目的

GitHub Actions の参照をフルレングスのコミット SHA にピン留めし、サプライチェーン上のリスク（タグの付け替えによる意図しないコード実行）を塞ぐ。あわせて、ピン留めが崩れたことを CI で検出できるようにする。

## 変更内容

`.github/workflows/test.yml` の 4 つの action をすべて `owner/repo@<40桁SHA> # vX.Y.Z` の形にピン留めした。

| action | ピン留め先 |
| --- | --- |
| `actions/checkout` | `11d5960a…` # v4.4.0 |
| `jdx/mise-action` | `9e7f7633…` # v4.2.3 |
| `actions/cache` | `0057852b…` # v4.3.0 |
| `suzuki-shunsuke/pinact-action` | `896d595f…` # v3.0.0 |

維持手段として、既存の `test` job に公式の `suzuki-shunsuke/pinact-action` を**検証専用**（`fix: 'false'` / `verify: 'true'`）で追加した。これにより push(main) と全 PR で「未ピン留めの参照」「SHA とバージョンコメントの不一致」が検出される。

## 設計上の判断

- **`.pinact.yaml` は追加していない。** pinact の既定探索（`.github/workflows/`）で全対象がカバーされ、設定すべき項目がなかったため。
- **job の追加も pre-commit フックの改変もしていない。** 既存 job に 1 step 足すだけで検証目的は達せられ、diff を 1 ファイルに抑えられる。
- **`mise.toml` への `pinact` 追加は見送った。** 全開発者にローカルインストールを強制する割に、CI で落ちれば十分検知できるため。必要になれば 1 行で追加できる。
- `pinact-action` は `v1` という移動タグが存在しなかったため、最新リリースの `v3.0.0` を採用した。v3 の `action.yaml` に `fix` / `verify` 入力があることを API で確認済み。

## 検証

- `pinact run` → 4 参照すべてを SHA + バージョンコメントに解決、exit 0
- `pinact run --check --verify` → 出力なし、exit 0
- `actionlint 1.7.7 .github/workflows/test.yml` → 出力なし、exit 0
- **ピン留め先 SHA 4 件すべてを `gh api` でタグ実体と照合し、完全一致を確認**（annotated tag は deref して比較）

## 備考

Action の**更新**自動化（Renovate 等）は本 PR の範囲外。SHA ピン留めは更新を止める副作用があるため、将来的に Renovate の `helpers:pinGitHubActionDigests` 併用を検討する価値がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDy7jBKfMCT43KRVyhxj2e