### PR TITLE
CI のクリティカルパス短縮と進行中 PR run の打ち切り

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,12 @@ jobs:
   check-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
       - name: Resolve pnpm store path
         run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# 同一ブランチで新しい push があれば進行中の PR 向け run を打ち切る
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # CI では prepare (vp config) による git hooks 導入をスキップする
   VITE_GIT_HOOKS: '0'
@@ -30,9 +35,25 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Format, lint and type check
-        run: pnpm check
       - name: Run simulation tests
         run: pnpm test
+
+  check-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4
+      - name: Resolve pnpm store path
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Format, lint and type check
+        run: pnpm check
       - name: Build bundle
         run: pnpm build


### PR DESCRIPTION
## 概要

Issue #124 の CI 高速化として、check/build をテストから分離して並列実行し、PR への連続 push 時は古い run を打ち切るようにします。効果は小さいものの、テスト内容やシミュレーション挙動を変えずに短縮できる範囲を実装しました。

Closes #124

## 実測とボトルネック

直近 10 run の job total は 89〜120 秒（中央値 約112秒）でした。ステップ別では `pnpm test` が 86秒（job時間の76〜84%）、`pnpm install` が2〜3秒（キャッシュヒット済み）、`pnpm check` が2〜3秒、`pnpm build` が1〜2秒です。ボトルネックはテスト実行に集中しています。

## 採用した変更

- check/build を別 job `check-and-build` に分離しました。クリティカルパスから3〜5秒削減し、102秒から約97秒（−4〜5%）になる見込みです。パブリックリポジトリなので追加 runner は課金対象外です。
- `concurrency` と `cancel-in-progress` を追加しました。打ち切りは pull_request のときだけ有効で、main は対象外です。同一ブランチへの連続 push により古い run が走り続けていた実例（1ブランチで4 run）があるため、runner の浪費を防ぎます。

効果が小さいことは認識しています。ボトルネックである86秒のテストは今回スコープ外（テスト内容の変更禁止）であり、これが構造的な上限です。

## 不採用案

- Vitest `--shard`: テストファイルが `traffic-simulation.test.ts` 1本しかなく、shard はファイル単位の分割なので、1シャードに全456テストが乗り、残りは空 job になります。高速化せず、空 job のセットアップ（各15〜25秒）と YAML の複雑化だけが増えるため明確に有害です。
- `pool` / `maxWorkers` / `fileParallelism`: 単一ファイルでは効果が誤差のため不採用です。
- install のキャッシュ最適化: #119 で実施済みで、伸びしろがありません。

## 今後の最大の伸びしろ

`vite.config.ts` の `sequence.concurrent: true` なら、テストファイルを触らず単一ファイル内を並行化でき、86秒を理論上コア数分短縮できる唯一の大きな手です。ただし、決定論性が生命線のプロジェクトであり、今回はホスト負荷（load average 49〜61、4コア）によりローカル検証が不可能でした。「検証できないものは入れない」と判断して見送りました。別 issue として、静かなマシンで「10シードのスコア差ガードが不変」であることを確認したうえで検討すべきです。

## レビュアーへの注意

ブランチ保護の必須チェックに `test` を指定している場合、job 分割により check/build の失敗が必須チェックに反映されなくなります。`check-and-build` を必須チェックへ追加するリポジトリ設定変更が必要です（コードでは対応できません）。

## Stacked PR

この変更は当初 `chore/122-pinact`（PR #125）を base とする stacked PR として作成しました。同じ `test.yml` を変更するため、#122 の上に積むことで CI のピン留め検証が通る状態で回す構成です。

PR #125 はすでにマージされ、`chore/122-pinact` ブランチも削除済みでした。削除されたブランチを base にすると PR を作成できないため、想定していた手順どおり base を `main` に付け替えた状態で作成しています。

## 検証

- `pinact run --check --verify`
- `actionlint`
- 7箇所すべての `uses:` が40桁 SHA であることを確認
- `git diff --stat chore/122-pinact HEAD` で変更が `.github/workflows/test.yml` のみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDy7jBKfMCT43KRVyhxj2e