### PR TITLE
fix: 車両追跡視点で背景・遠景を完全ループ化する (#127)

### DIFF
--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -4,7 +4,8 @@ import { CONST, clamp, smooth } from '../core';
 import type { Vehicle, World } from '../core';
 import { isLandscapeViewport } from './camera-layout';
 import { flybyPose } from './flyby';
-import { camera, renderer } from './scene';
+import { camera, renderer, syncBackgroundAnchor } from './scene';
+import { cameraWrapOffset } from './looping';
 
 export interface CameraController {
   theta: number;
@@ -73,8 +74,12 @@ export interface SpectatorPreset {
    区間内から1台選び、退場するか止まるまで同じ車を追い続ける */
 let followVehicle: Vehicle | null = null;
 let followChanged = false; // 追う車が入れ替わったフレームを知らせる(視点を繋ぎ直すため)
+let previousFollowZ: number | null = null;
+let pendingCameraWrap = 0;
 function pickFollowVehicle(world: World): Vehicle | null {
   if (followVehicle && !followVehicle.waiting && world.vehicles.includes(followVehicle)) {
+    pendingCameraWrap = cameraWrapOffset(previousFollowZ ?? followVehicle.z, followVehicle.z);
+    previousFollowZ = followVehicle.z;
     return followVehicle;
   }
   // 画面中央付近(z≈0)を走行中の車を選ぶ。見失ったら選び直す
@@ -90,6 +95,8 @@ function pickFollowVehicle(world: World): Vehicle | null {
   }
   followVehicle = best;
   followChanged = true;
+  previousFollowZ = best?.z ?? null;
+  pendingCameraWrap = 0;
   return best;
 }
 // 追う車がいないときの逃げ場(生成直後など)。俯瞰気味に全体を映す
@@ -352,6 +359,14 @@ function updateSpectator(world: World, deltaTime: number): void {
     time: spectator.presetTime,
     world,
   });
+  if (pendingCameraWrap !== 0) {
+    // 車両と同時に同じ周回複製へ移し、補間が816mを横切らないようにする。
+    currentPose.position.z += pendingCameraWrap;
+    currentPose.target.z += pendingCameraWrap;
+    fromPose.position.z += pendingCameraWrap;
+    fromPose.target.z += pendingCameraWrap;
+    pendingCameraWrap = 0;
+  }
   // 追う車が入れ替わった時も繋ぎ直す(視点が瞬間移動せず、別の車へ寄っていく)
   if (followChanged) {
     followChanged = false;
@@ -382,6 +397,7 @@ export function updateCamera(world?: World, deltaTime = 0): void {
   } else {
     applyOrbit();
   }
+  syncBackgroundAnchor();
 }
 
 export function setupCameraControls(): void {

--- a/src/render/looping.ts
+++ b/src/render/looping.ts
@@ -7,3 +7,11 @@ import { WRAP_LENGTH } from '../core';
 export function loopCopies(z: number): [number, number, number] {
   return [z - WRAP_LENGTH, z, z + WRAP_LENGTH];
 }
+
+/** 周回境界をまたいだ追尾対象に合わせ、カメラを同じ複製位置へ移す量を返す。 */
+export function cameraWrapOffset(previousZ: number, currentZ: number): number {
+  const delta = currentZ - previousZ;
+  if (delta > WRAP_LENGTH / 2) return WRAP_LENGTH;
+  if (delta < -WRAP_LENGTH / 2) return -WRAP_LENGTH;
+  return 0;
+}

--- a/src/render/night.ts
+++ b/src/render/night.ts
@@ -1,7 +1,7 @@
 /* ================= ナイトモード用アセット(空・星・月・街灯・投光) ================= */
 import * as THREE from 'three';
-import { CONST } from '../core';
-import { scene } from './scene';
+import { WRAP_LENGTH } from '../core';
+import { backgroundAnchor, scene } from './scene';
 import {
   starMaterial,
   moonMaterial,
@@ -13,13 +13,15 @@ import {
 } from './materials';
 import { GANTRY_Z, SECTIONS, sectionX } from './track';
 import { instancedAt, instancedWith } from './instancing';
-
-const ROAD_HALF = CONST.ROAD_HALF;
+import { loopCopies } from './looping';
 
 // 夜だけ表示するものをまとめるグループ
 export const nightGroup = new THREE.Group();
 nightGroup.visible = false;
 scene.add(nightGroup);
+export const nightSkyGroup = new THREE.Group();
+nightSkyGroup.visible = false;
+backgroundAnchor.add(nightSkyGroup);
 
 // 空: 縦グラデーションのドーム(昼ドームの内側に夜ドームを重ね、opacityでクロスフェード)
 function makeSkyDome(
@@ -46,7 +48,7 @@ function makeSkyDome(
     }),
   );
   mesh.renderOrder = order;
-  scene.add(mesh);
+  backgroundAnchor.add(mesh);
   return mesh;
 }
 makeSkyDome(
@@ -87,7 +89,7 @@ nightDome.material.opacity = 0;
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   const stars = new THREE.Points(geometry, starMaterial);
   stars.renderOrder = -18;
-  nightGroup.add(stars);
+  nightSkyGroup.add(stars);
 })();
 
 // 月(ハロー付き)
@@ -96,12 +98,12 @@ nightDome.material.opacity = 0;
   moon.position.set(330, 520, 260);
   moon.lookAt(0, 0, 0);
   moon.renderOrder = -17;
-  nightGroup.add(moon);
+  nightSkyGroup.add(moon);
   const halo = new THREE.Sprite(haloMaterial);
   halo.scale.set(170, 170, 1);
   halo.position.copy(moon.position);
   halo.renderOrder = -17;
-  nightGroup.add(halo);
+  nightSkyGroup.add(halo);
 })();
 
 // 街灯(区間の仕切りの上から両側へアームを伸ばすダブルアーム式・ナトリウム灯)。
@@ -127,21 +129,24 @@ const LAMP_GLOW_OFFSET_X = 3.6;
   const headPositions: [number, number, number][] = [];
   const glowMatrices: THREE.Matrix4[] = [];
   const glowRotation = new THREE.Matrix4().makeRotationX(-Math.PI / 2);
-  for (let z = -ROAD_HALF + 14; z < ROAD_HALF; z += 42) {
-    polePositions.push([LAMP_ROW_X, 3.6, z]);
-    armPositions.push([LAMP_ROW_X, 7.1, z]);
-    for (const side of [-1, 1]) {
-      headPositions.push([LAMP_ROW_X + side * LAMP_HEAD_OFFSET_X, 7.0, z]);
-      // 電球のにじみ(夜のみ): 灯具が光源として「光って見える」ように
-      // 発光表現が影を落とすと不自然なため castShadow は設定しない
-      const bulb = new THREE.Sprite(bulbMaterial);
-      bulb.scale.set(2.6, 2.6, 1);
-      bulb.position.set(LAMP_ROW_X + side * LAMP_HEAD_OFFSET_X, 6.92, z);
-      nightGroup.add(bulb);
-      // 路面の光だまり(夜のみ)
-      glowMatrices.push(
-        glowRotation.clone().setPosition(LAMP_ROW_X + side * LAMP_GLOW_OFFSET_X, 0.03, z),
-      );
+  const lampSpacing = WRAP_LENGTH / 24;
+  for (let z = -WRAP_LENGTH / 2 + lampSpacing / 2; z < WRAP_LENGTH / 2; z += lampSpacing) {
+    for (const copyZ of loopCopies(z)) {
+      polePositions.push([LAMP_ROW_X, 3.6, copyZ]);
+      armPositions.push([LAMP_ROW_X, 7.1, copyZ]);
+      for (const side of [-1, 1]) {
+        headPositions.push([LAMP_ROW_X + side * LAMP_HEAD_OFFSET_X, 7.0, copyZ]);
+        // 電球のにじみ(夜のみ): 灯具が光源として「光って見える」ように
+        // 発光表現が影を落とすと不自然なため castShadow は設定しない
+        const bulb = new THREE.Sprite(bulbMaterial);
+        bulb.scale.set(2.6, 2.6, 1);
+        bulb.position.set(LAMP_ROW_X + side * LAMP_HEAD_OFFSET_X, 6.92, copyZ);
+        nightGroup.add(bulb);
+        // 路面の光だまり(夜のみ)
+        glowMatrices.push(
+          glowRotation.clone().setPosition(LAMP_ROW_X + side * LAMP_GLOW_OFFSET_X, 0.03, copyZ),
+        );
+      }
     }
   }
   const poles = instancedAt(poleGeometry, poleMaterial, polePositions);

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -9,6 +9,14 @@ export const scene = new THREE.Scene();
 scene.background = new THREE.Color(SKY_COLOR);
 scene.fog = new THREE.Fog(SKY_COLOR, 140, 420); // 遠景処理: 遠方が背景に溶け込む
 
+// 遠景と地面をカメラの進行位置へ追従させ、周回を重ねても相対位置を保つ。
+export const backgroundAnchor = new THREE.Group();
+scene.add(backgroundAnchor);
+
+export function syncBackgroundAnchor(): void {
+  backgroundAnchor.position.z = camera.position.z;
+}
+
 export const camera = new THREE.PerspectiveCamera(55, innerWidth / innerHeight, 0.5, 1200);
 
 function createRenderer(): THREE.WebGLRenderer {
@@ -81,4 +89,4 @@ const ground = new THREE.Mesh(
 ground.rotation.x = -Math.PI / 2;
 ground.position.y = -0.18;
 ground.receiveShadow = true;
-scene.add(ground);
+backgroundAnchor.add(ground);

--- a/src/render/scenery.ts
+++ b/src/render/scenery.ts
@@ -2,13 +2,11 @@
    道路施設(track.js)とは別の「風景」を担当する。
    山・雲のマテリアルは materials.js にあり、昼夜の色は theme.js が補間する */
 import * as THREE from 'three';
-import { CONST, WRAP_LENGTH } from '../core';
-import { scene } from './scene';
+import { WRAP_LENGTH } from '../core';
+import { backgroundAnchor, scene } from './scene';
 import { mountainFarMaterial, mountainNearMaterial, cloudMaterial } from './materials';
 import { instancedAt } from './instancing';
 import { loopCopies } from './looping';
-
-const ROAD_HALF = CONST.ROAD_HALF;
 
 /* ---- 路側の防護柵(ガードレール) ---- */
 (function buildRoadside() {
@@ -44,16 +42,19 @@ const ROAD_HALF = CONST.ROAD_HALF;
       zEnd = -130,
       length = zEnd - zStart,
       zCenter = (zStart + zEnd) / 2;
-    const base = new THREE.Mesh(new THREE.BoxGeometry(0.3, 1.5, length), wallMaterial);
-    base.position.set(19.2 * side, 0.75, zCenter);
-    base.castShadow = true;
-    scene.add(base);
-    const panel = new THREE.Mesh(new THREE.BoxGeometry(0.14, 1.7, length), panelMaterial);
-    panel.position.set(19.2 * side, 2.35, zCenter);
-    // three r128 では半透明の影は不透明になるが、下段の影が途中で切れる違和感を避ける
-    panel.castShadow = true;
-    scene.add(panel);
-    for (let z = zStart; z <= zEnd; z += 10) wallPostPositions.push([19.2 * side, 1.6, z]);
+    for (const offset of loopCopies(0)) {
+      const base = new THREE.Mesh(new THREE.BoxGeometry(0.3, 1.5, length), wallMaterial);
+      base.position.set(19.2 * side, 0.75, zCenter + offset);
+      base.castShadow = true;
+      scene.add(base);
+      const panel = new THREE.Mesh(new THREE.BoxGeometry(0.14, 1.7, length), panelMaterial);
+      panel.position.set(19.2 * side, 2.35, zCenter + offset);
+      // three r128 では半透明の影は不透明になるが、下段の影が途中で切れる違和感を避ける
+      panel.castShadow = true;
+      scene.add(panel);
+      for (let z = zStart; z <= zEnd; z += 10)
+        wallPostPositions.push([19.2 * side, 1.6, z + offset]);
+    }
   }
   const wallPosts = instancedAt(wallPostGeometry, wallPostMaterial, wallPostPositions);
   wallPosts.castShadow = true;
@@ -69,12 +70,12 @@ const ROAD_HALF = CONST.ROAD_HALF;
   const trunks = new THREE.InstancedMesh(
     trunkGeometry,
     new THREE.MeshLambertMaterial({ color: 0x6b4e35 }),
-    treeCount,
+    treeCount * 3,
   );
   const canopies = new THREE.InstancedMesh(
     canopyGeometry,
     new THREE.MeshLambertMaterial({ color: 0xffffff }),
-    treeCount,
+    treeCount * 3,
   );
   trunks.castShadow = true;
   canopies.castShadow = true;
@@ -86,21 +87,23 @@ const ROAD_HALF = CONST.ROAD_HALF;
   for (let i = 0; i < treeCount; i++) {
     const side = Math.random() < 0.5 ? -1 : 1;
     const x = side * (22 + Math.pow(Math.random(), 1.6) * 70);
-    const z = -ROAD_HALF + Math.random() * ROAD_HALF * 2;
+    const z = -WRAP_LENGTH / 2 + Math.random() * WRAP_LENGTH;
     const height = 2.4 + Math.random() * 3.6; // 幹の高さ
     const radius = height * (0.42 + Math.random() * 0.22); // 樹冠の半径
-    matrix.makeScale(1 + radius * 0.3, height, 1 + radius * 0.3).setPosition(x, 0, z);
-    trunks.setMatrixAt(i, matrix);
-    matrix
-      .makeScale(radius, radius * (0.9 + Math.random() * 0.5), radius)
-      .setPosition(x, height + radius * 0.5, z);
-    canopies.setMatrixAt(i, matrix);
+    const canopyHeight = radius * (0.9 + Math.random() * 0.5);
     color.setHSL(
       0.26 + Math.random() * 0.09,
       0.35 + Math.random() * 0.25,
       0.26 + Math.random() * 0.14,
     );
-    canopies.setColorAt(i, color);
+    loopCopies(z).forEach((copyZ, copyIndex) => {
+      const index = i * 3 + copyIndex;
+      matrix.makeScale(1 + radius * 0.3, height, 1 + radius * 0.3).setPosition(x, 0, copyZ);
+      trunks.setMatrixAt(index, matrix);
+      matrix.makeScale(radius, canopyHeight, radius).setPosition(x, height + radius * 0.5, copyZ);
+      canopies.setMatrixAt(index, matrix);
+      canopies.setColorAt(index, color);
+    });
   }
   scene.add(trunks, canopies);
 })();
@@ -114,7 +117,7 @@ const ROAD_HALF = CONST.ROAD_HALF;
   );
   far.position.y = 66;
   far.renderOrder = -16;
-  scene.add(far);
+  backgroundAnchor.add(far);
   const near = new THREE.Mesh(
     new THREE.CylinderGeometry(760, 760, 130, 72, 1, true),
     mountainNearMaterial,
@@ -122,7 +125,7 @@ const ROAD_HALF = CONST.ROAD_HALF;
   near.position.y = 40;
   near.rotation.y = 2.1;
   near.renderOrder = -15;
-  scene.add(near);
+  backgroundAnchor.add(near);
 })();
 
 /* ---- 雲 ---- */
@@ -152,6 +155,6 @@ const ROAD_HALF = CONST.ROAD_HALF;
     sprite.scale.set(width, width * aspect, 1);
     sprite.position.set(centerX, centerY, centerZ);
     sprite.renderOrder = -14;
-    scene.add(sprite);
+    backgroundAnchor.add(sprite);
   }
 })();

--- a/src/render/theme.ts
+++ b/src/render/theme.ts
@@ -17,7 +17,7 @@ import {
   mountainNearMaterial,
   cloudMaterial,
 } from './materials';
-import { nightGroup, nightDome } from './night';
+import { nightGroup, nightSkyGroup, nightDome } from './night';
 
 export interface EnvSpec {
   background: number;
@@ -124,6 +124,7 @@ export function applyEnv(): void {
   // 夜専用アセットはまとめてフェード
   nightDome.material.opacity = mix;
   nightGroup.visible = mix > 0.02;
+  nightSkyGroup.visible = mix > 0.02;
   starMaterial.opacity = mix;
   moonMaterial.opacity = mix;
   haloMaterial.opacity = mix * 0.9;

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -37,7 +37,7 @@ import {
 } from './src/core';
 import { isLandscapeViewport } from './src/render/camera-layout';
 import { flybyPose } from './src/render/flyby';
-import { loopCopies } from './src/render/looping';
+import { cameraWrapOffset, loopCopies } from './src/render/looping';
 
 /* ---------- ヘルパー: シナリオ実行 ---------- */
 const TIME_STEP = 1 / 20;
@@ -3711,5 +3711,16 @@ describe('依存注入 (Issue #120)', () => {
       return world.vehicles.map((vehicle) => vehicle.z);
     };
     expect(runSteps(createWorldDeps())).toEqual(runSteps());
+  });
+});
+
+describe('追尾カメラの周回境界 (Issue #127)', () => {
+  test('車両が進行方向へ周回したときカメラを次の複製へ繋ぎ直す', () => {
+    expect(cameraWrapOffset(-407, 407)).toBe(WRAP_LENGTH);
+  });
+
+  test('通常走行と逆向きの境界通過を区別する', () => {
+    expect(cameraWrapOffset(120, 119)).toBe(0);
+    expect(cameraWrapOffset(407, -407)).toBe(-WRAP_LENGTH);
   });
 });


### PR DESCRIPTION
Closes #127

## 概要

追尾視点・ドライバー視点で走り続けると、周回境界（seam）で背景が途切れて「ここが継ぎ目だ」と分かってしまう問題があった。道路本体だけでなく、路側設備（街路樹・遮音壁・街灯）・遠景（山・雲・空ドーム）・地面まで含めて完全にループ化し、どこを走っても継ぎ目が見えないようにした。

## 変更内容

| 対象 | 変更 |
| --- | --- |
| 街路樹・遮音壁・壁支柱・街灯 | `loopCopies()` で前後1周ぶんを複製。分布レンジを `ROAD_HALF*2`（800m）から `WRAP_LENGTH`（816m）へ是正し、seam に空いていた 16m の空白を解消 |
| 街灯の間隔 | 42m から `WRAP_LENGTH / 24 = 34m`（`WRAP_LENGTH` の約数）へ調整し、seam 前後で灯の間隔が乱れる問題を解消 |
| 空ドーム・山・雲・地面・星/月/ハロー | 新設の `backgroundAnchor` Group 配下へ移動し、毎フレーム `camera.position.z` に追従させる（`syncBackgroundAnchor()`） |
| 追尾カメラ | `cameraWrapOffset()` を追加。追跡車両が `WRAP_LENGTH` をまたいだフレームで `currentPose` / `fromPose` を同じ複製位置へ移し、816m のワープを解消 |
| 夜空要素 | `nightSkyGroup` として分離し、`theme.ts` から可視制御 |

## 実験的妥当性への影響なし

- 変更は `src/render/` とテストのみ。`src/core/` は無変更。
- `loopCopies` / `cameraWrapOffset` はいずれも引数が z のみで、`section` / `yields` などの区間依存変数を描画分岐に使っていない（AGENTS.md A 節の不変条件を維持）。
- `instancing.ts` も無変更。

## 検証結果

- `pnpm check` pass（45 ファイル整形済み / 35 ファイル警告なし）
- `pnpm test` 179/179 passed
- `pnpm build` 成功
- 回帰ガード `渋滞スコア差` 11 件 PASS（`DIFF_TARGET = 4` 維持）
- 新規テスト `追尾カメラの周回境界 (Issue #127)` 2 件 PASS

## レビュー時に確認してほしいこと（未検証事項）

1. **目視確認が未実施**: CI 環境に WebGL ドライバがなく Three.js の初期化に到達できないため、昼・夜で数周走らせた seam の目視確認ができていない。
2. **z 方向の遠景パララックスが失われる**: 遠景と地面をカメラ z に完全追従させたため、山が後ろへ流れなくなる（x 方向のパララックスは残る）。Issue の方針どおりだが、見え方として許容かは要判断。
3. **描画負荷は未計測**: 街灯は密度 1.24 倍 × 3 複製で約 3.7 倍、街路樹・遮音壁も 3 倍になっている。低スペック端末でのフレームレート確認を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
