### PR TITLE
カメラモード選択メニューを実装する

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,10 +76,13 @@
       id="spectatorBtn"
       title="カメラ: オートモード(押して切替)"
       aria-label="カメラ: オートモード(押して切替)"
+      aria-expanded="false"
+      aria-controls="spectatorMenu"
     >
       <i data-lucide="clapperboard"></i>
     </button>
     <div id="spectatorLabel"></div>
+    <div id="spectatorMenu" aria-label="カメラモード"></div>
 
     <!-- パネル配置レイヤー（コントロールパネルと情報パネルの位置関係をまとめて決める） -->
     <div id="panelLayer">

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -208,12 +208,11 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
    先頭は「マニュアルモード(自分で視点を操作する)」、次が「オートモード」、
    以降は各プリセットの手動固定。オートモードも1つのモードとして循環に含める */
 export interface SpectatorMode {
-  id: 'manual' | 'auto' | SpectatorPresetId;
+  id: 'auto' | SpectatorPresetId;
   label: string;
   icon: string;
 }
 export const SPECTATOR_MODES: SpectatorMode[] = [
-  { id: 'manual', label: 'マニュアルモード', icon: 'mouse' },
   { id: 'auto', label: 'オートモード', icon: 'repeat' },
   ...SPECTATOR_PRESETS.map((preset) => ({
     id: preset.id,
@@ -221,9 +220,8 @@ export const SPECTATOR_MODES: SpectatorMode[] = [
     icon: preset.icon,
   })),
 ];
-const MANUAL_MODE_INDEX = 0;
-const AUTO_MODE_INDEX = 1;
-const FIRST_PRESET_MODE_INDEX = 2;
+const AUTO_MODE_INDEX = 0;
+const FIRST_PRESET_MODE_INDEX = 1;
 
 const AUTO_CYCLE_INTERVAL = 9; // オートモードでプリセットを切り替える間隔 (s)
 const TRANSITION_DURATION = 1.2; // 視点の切り替えにかける時間 (s)
@@ -257,7 +255,7 @@ export interface SpectatorStatus {
 }
 export function getSpectatorStatus(): SpectatorStatus {
   return {
-    enabled: spectator.modeIndex !== MANUAL_MODE_INDEX,
+    enabled: true,
     auto: spectator.modeIndex === AUTO_MODE_INDEX,
     mode: SPECTATOR_MODES[spectator.modeIndex],
   };
@@ -315,17 +313,7 @@ function syncOrbitFromCamera(): void {
 function setMode(index: number): void {
   const previous = spectator.modeIndex;
   spectator.modeIndex = (index + SPECTATOR_MODES.length) % SPECTATOR_MODES.length;
-  if (previous === MANUAL_MODE_INDEX && spectator.modeIndex !== MANUAL_MODE_INDEX) {
-    // マニュアルモードから入る: 今のカメラ位置から飛び始める(いきなり瞬間移動しない)
-    currentPose.position.copy(camera.position);
-    currentPose.target.copy(cameraController.target);
-  }
-  if (spectator.modeIndex === MANUAL_MODE_INDEX) {
-    // マニュアルモードへ戻す。今の見え方をそのまま軌道パラメータへ引き継ぐ
-    syncOrbitFromCamera();
-    followVehicle = null;
-    progressListener?.(0);
-  } else if (spectator.modeIndex === AUTO_MODE_INDEX) {
+  if (spectator.modeIndex === AUTO_MODE_INDEX) {
     // オートモードは先頭のプリセットから始める
     switchPreset(0);
   } else {
@@ -339,9 +327,15 @@ export function cycleSpectatorMode(): void {
   setMode(spectator.modeIndex + 1);
 }
 
+/** メニューやショートカットから目的のモードへ直接切り替える */
+export function selectSpectatorMode(id: SpectatorMode['id']): void {
+  const index = SPECTATOR_MODES.findIndex((mode) => mode.id === id);
+  if (index >= 0) setMode(index);
+}
+
 /** マニュアルモードへ戻す(画面のタップ・ドラッグ・ホイール操作から呼ばれる) */
 export function enterManualMode(): void {
-  if (spectator.modeIndex !== MANUAL_MODE_INDEX) setMode(MANUAL_MODE_INDEX);
+  syncOrbitFromCamera();
 }
 
 function updateSpectator(world: World, deltaTime: number): void {
@@ -392,7 +386,7 @@ function updateSpectator(world: World, deltaTime: number): void {
    マニュアルモードなら従来の軌道カメラ、それ以外はプリセットで描く。
    world/deltaTime はプリセット描画のときだけ使う(初期化時の引数なし呼び出しも許容) */
 export function updateCamera(world?: World, deltaTime = 0): void {
-  if (spectator.modeIndex !== MANUAL_MODE_INDEX && world) {
+  if (world) {
     updateSpectator(world, deltaTime);
   } else {
     applyOrbit();

--- a/src/style.css
+++ b/src/style.css
@@ -621,6 +621,47 @@ body.night #nightBtn {
   opacity: 1;
   transform: translateY(0);
 }
+#spectatorMenu {
+  display: none;
+  position: fixed;
+  top: 78px;
+  right: 78px;
+  z-index: 31;
+  width: 210px;
+  padding: 10px;
+  border-radius: 12px;
+  color: #fff;
+  background: rgba(3, 38, 27, 0.94);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+}
+#spectatorMenu.open {
+  display: block;
+}
+.camera-menu-heading {
+  padding: 5px 8px;
+  font-size: 11px;
+  opacity: 0.7;
+}
+.camera-menu-group button {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px;
+  border: 0;
+  border-radius: 8px;
+  color: inherit;
+  background: transparent;
+  text-align: left;
+}
+.camera-menu-group button:hover,
+.camera-menu-group button.selected {
+  background: rgba(255, 213, 74, 0.2);
+}
+.camera-menu-group .lucide {
+  width: 18px;
+  height: 18px;
+}
 @media (max-width: 700px) {
   #spectatorBtn {
     width: 50px;

--- a/src/ui/spectator.ts
+++ b/src/ui/spectator.ts
@@ -4,10 +4,11 @@
    マニュアル → オート → 各プリセット → マニュアル… と循環させる。
    カメラ状態そのものは render/camera.ts が持ち、ここは操作と表示だけを行う。 */
 import {
-  cycleSpectatorMode,
+  SPECTATOR_MODES,
   getSpectatorStatus,
   onSpectatorChange,
   onSpectatorProgress,
+  selectSpectatorMode,
 } from '../render/camera';
 import type { SpectatorStatus } from '../render/camera';
 import { icon, renderIcons } from './icons';
@@ -17,6 +18,7 @@ const MODE_LABEL_DURATION_MS = 3000;
 export function setupSpectator(): void {
   const button = document.getElementById('spectatorBtn')!;
   const label = document.getElementById('spectatorLabel')!;
+  const menu = document.getElementById('spectatorMenu')!;
   let labelTimer: ReturnType<typeof setTimeout> | undefined;
 
   function render(status: SpectatorStatus, showLabel: boolean): void {
@@ -36,9 +38,38 @@ export function setupSpectator(): void {
     button.title = title;
     button.setAttribute('aria-label', title);
     renderIcons();
+    menu.querySelectorAll<HTMLButtonElement>('[data-camera-mode]').forEach((item) => {
+      item.classList.toggle('selected', item.dataset.cameraMode === status.mode.id);
+    });
   }
 
-  button.addEventListener('click', cycleSpectatorMode);
+  const groups = [
+    ['オート', SPECTATOR_MODES.filter((mode) => mode.id === 'auto')],
+    [
+      '全体を見る',
+      SPECTATOR_MODES.filter((mode) =>
+        ['drone', 'overhead', 'lookup', 'flyby', 'ramp'].includes(mode.id),
+      ),
+    ],
+    ['車から見る', SPECTATOR_MODES.filter((mode) => ['follow', 'driver'].includes(mode.id))],
+  ] as const;
+  menu.innerHTML = groups
+    .map(
+      ([name, modes]) =>
+        `<div class="camera-menu-group"><div class="camera-menu-heading">${name}</div>${modes.map((mode) => `<button type="button" data-camera-mode="${mode.id}">${icon(mode.icon)}<span>${mode.label}</span></button>`).join('')}</div>`,
+    )
+    .join('');
+  button.addEventListener('click', () => {
+    const open = menu.classList.toggle('open');
+    button.setAttribute('aria-expanded', String(open));
+  });
+  menu.addEventListener('click', (event) => {
+    const item = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-camera-mode]');
+    if (!item) return;
+    selectSpectatorMode(item.dataset.cameraMode as Parameters<typeof selectSpectatorMode>[0]);
+    menu.classList.remove('open');
+    button.setAttribute('aria-expanded', 'false');
+  });
   onSpectatorChange((status) => render(status, true));
   onSpectatorProgress((progress) => {
     button.style.setProperty('--auto-cycle-progress', String(progress));


### PR DESCRIPTION
## 概要

循環ボタンを、オート・全体を見る・車から見るに分類した直接選択メニューへ置き換えます。起動時は従来どおりオートです。

## Stack

- base: `main`
- head: `issue-135-camera-menu`
- このStackの第1層です。

Closes #135