### PR TITLE
追尾・ドライバー視点の操作バーを追加する

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,11 @@
     <div id="spectatorMenu" aria-label="カメラモード"></div>
     <button id="cameraResetBtn" type="button" hidden>視点を戻す</button>
     <div id="cameraPanHint" hidden>Shift+ドラッグ／2本指で道路沿いに移動</div>
+    <div id="vehicleCameraBar" class="camera-operation-bar" hidden>
+      <button type="button" data-section="L">L</button>
+      <button type="button" data-section="R">R</button>
+      <button id="nextVehicleBtn" type="button">次の車</button>
+    </div>
 
     <!-- パネル配置レイヤー（コントロールパネルと情報パネルの位置関係をまとめて決める） -->
     <div id="panelLayer">

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -1,7 +1,7 @@
 /* ================= カメラ操作（回転・ズーム・カメラモード） ================= */
 import * as THREE from 'three';
 import { CONST, clamp, smooth } from '../core';
-import type { Vehicle, World } from '../core';
+import type { Section, Vehicle, World } from '../core';
 import { isLandscapeViewport } from './camera-layout';
 import { flybyPose } from './flyby';
 import { camera, renderer, syncBackgroundAnchor } from './scene';
@@ -76,23 +76,27 @@ let followVehicle: Vehicle | null = null;
 let followChanged = false; // 追う車が入れ替わったフレームを知らせる(視点を繋ぎ直すため)
 let previousFollowZ: number | null = null;
 let pendingCameraWrap = 0;
+let followSection: Section = 'L';
+let skipFollowVehicle: Vehicle | null = null;
 function pickFollowVehicle(world: World): Vehicle | null {
-  if (followVehicle && !followVehicle.waiting && world.vehicles.includes(followVehicle)) {
+  if (
+    followVehicle &&
+    followVehicle.section === followSection &&
+    !followVehicle.waiting &&
+    world.vehicles.includes(followVehicle)
+  ) {
     pendingCameraWrap = cameraWrapOffset(previousFollowZ ?? followVehicle.z, followVehicle.z);
     previousFollowZ = followVehicle.z;
     return followVehicle;
   }
   // 画面中央付近(z≈0)を走行中の車を選ぶ。見失ったら選び直す
-  let best: Vehicle | null = null;
-  let bestScore = Infinity;
-  for (const vehicle of world.vehicles) {
-    if (vehicle.waiting || vehicle.speed < 6) continue;
-    const score = Math.abs(vehicle.z);
-    if (score < bestScore) {
-      bestScore = score;
-      best = vehicle;
-    }
-  }
+  const candidates = world.vehicles.filter(
+    (vehicle) =>
+      vehicle.section === followSection && !vehicle.waiting && vehicle !== skipFollowVehicle,
+  );
+  const best = candidates[Math.floor(Math.random() * candidates.length)] ?? null;
+  skipFollowVehicle = null;
+  if (followVehicle && best !== followVehicle) resetCameraAdjustment();
   followVehicle = best;
   followChanged = true;
   previousFollowZ = best?.z ?? null;
@@ -266,6 +270,7 @@ export interface SpectatorStatus {
   auto: boolean;
   mode: SpectatorMode; // トグルボタンが示す現在のモード
   adjusted: boolean;
+  section: Section;
 }
 export function getSpectatorStatus(): SpectatorStatus {
   return {
@@ -277,6 +282,7 @@ export function getSpectatorStatus(): SpectatorStatus {
       spectator.pitchOffset !== 0 ||
       spectator.zoom !== 1 ||
       spectator.panOffsetZ !== 0,
+    section: followSection,
   };
 }
 
@@ -326,6 +332,21 @@ function panFixedCamera(deltaZ: number): void {
   if (!isFixedPreset()) return;
   spectator.panOffsetZ = clamp(spectator.panOffsetZ + deltaZ, -180, 180);
   notify();
+}
+
+/** カメラが表示する区間を選ぶ（シミュレーションの車両挙動には影響しない） */
+export function selectCameraSection(section: Section): void {
+  if (followSection === section) return;
+  followSection = section;
+  followVehicle = null;
+  resetCameraAdjustment();
+}
+
+/** 同じ区間内の別の車両へ追尾対象を切り替える */
+export function selectNextFollowVehicle(): void {
+  skipFollowVehicle = followVehicle;
+  followVehicle = null;
+  resetCameraAdjustment();
 }
 
 // 表示するプリセットを切り替える。今の姿勢から新しい姿勢へ補間を始める

--- a/src/style.css
+++ b/src/style.css
@@ -685,6 +685,29 @@ body.night #nightBtn {
   font-size: 11px;
   pointer-events: none;
 }
+.camera-operation-bar {
+  position: fixed;
+  right: 14px;
+  bottom: 18px;
+  z-index: 30;
+  display: flex;
+  gap: 5px;
+  padding: 6px;
+  border-radius: 10px;
+  background: rgba(3, 38, 27, 0.9);
+}
+.camera-operation-bar[hidden] {
+  display: none;
+}
+.camera-operation-bar button {
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 7px;
+}
+.camera-operation-bar button.selected {
+  color: #173b20;
+  background: #ffd54a;
+}
 @media (max-width: 700px) {
   #spectatorBtn {
     width: 50px;

--- a/src/ui/spectator.ts
+++ b/src/ui/spectator.ts
@@ -9,6 +9,8 @@ import {
   onSpectatorChange,
   onSpectatorProgress,
   resetCameraAdjustment,
+  selectCameraSection,
+  selectNextFollowVehicle,
   selectSpectatorMode,
 } from '../render/camera';
 import type { SpectatorStatus } from '../render/camera';
@@ -22,6 +24,7 @@ export function setupSpectator(): void {
   const menu = document.getElementById('spectatorMenu')!;
   const resetButton = document.getElementById('cameraResetBtn')!;
   const panHint = document.getElementById('cameraPanHint')!;
+  const vehicleBar = document.getElementById('vehicleCameraBar')!;
   let labelTimer: ReturnType<typeof setTimeout> | undefined;
 
   function render(status: SpectatorStatus, showLabel: boolean): void {
@@ -46,6 +49,10 @@ export function setupSpectator(): void {
     });
     resetButton.hidden = !status.adjusted;
     panHint.hidden = !['overhead', 'lookup', 'ramp'].includes(status.mode.id);
+    vehicleBar.hidden = !['follow', 'driver'].includes(status.mode.id);
+    vehicleBar.querySelectorAll<HTMLButtonElement>('[data-section]').forEach((item) => {
+      item.classList.toggle('selected', item.dataset.section === status.section);
+    });
   }
 
   const groups = [
@@ -76,6 +83,12 @@ export function setupSpectator(): void {
     button.setAttribute('aria-expanded', 'false');
   });
   resetButton.addEventListener('click', resetCameraAdjustment);
+  vehicleBar.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement;
+    const sectionButton = target.closest<HTMLButtonElement>('[data-section]');
+    if (sectionButton) selectCameraSection(sectionButton.dataset.section as 'L' | 'R');
+    if (target.closest('#nextVehicleBtn')) selectNextFollowVehicle();
+  });
   onSpectatorChange((status) => render(status, true));
   onSpectatorProgress((progress) => {
     button.style.setProperty('--auto-cycle-progress', String(progress));


### PR DESCRIPTION
## 概要

追尾・ドライバー視点にL/R選択と「次の車」を追加します。対象は速度低下では変更せず、退場時だけ同じ区間から再選択し、その際は視点微調整もリセットします。表示対象だけを切り替え、`src/core/`は変更しません。

## Stack

- base: `issue-133-auto-pause`
- head: `issue-136-follow-controls`
- #139 の上に積層します。

Closes #136