### PR TITLE
カメラ操作のキーボードショートカットを追加する

### DIFF
--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -337,6 +337,13 @@ function panFixedCamera(deltaZ: number): void {
   notify();
 }
 
+/** キーボード操作から現在の視点を少しだけ首振りする */
+export function adjustCamera(yaw: number, pitch: number): void {
+  spectator.yawOffset += yaw;
+  spectator.pitchOffset = clamp(spectator.pitchOffset + pitch, -1.2, 1.2);
+  notify();
+}
+
 /** カメラが表示する区間を選ぶ（シミュレーションの車両挙動には影響しない） */
 export function selectCameraSection(section: Section): void {
   if (followSection === section) return;

--- a/src/ui/spectator.ts
+++ b/src/ui/spectator.ts
@@ -5,6 +5,7 @@
    カメラ状態そのものは render/camera.ts が持ち、ここは操作と表示だけを行う。 */
 import {
   SPECTATOR_MODES,
+  adjustCamera,
   getSpectatorStatus,
   onSpectatorChange,
   onSpectatorProgress,
@@ -91,6 +92,27 @@ export function setupSpectator(): void {
     const sectionButton = target.closest<HTMLButtonElement>('[data-section]');
     if (sectionButton) selectCameraSection(sectionButton.dataset.section as 'L' | 'R');
     if (target.closest('#nextVehicleBtn')) selectNextFollowVehicle();
+  });
+  document.addEventListener('keydown', (event) => {
+    const target = event.target as HTMLElement;
+    if (target.matches('input, textarea, select, button') || target.isContentEditable) return;
+    const status = getSpectatorStatus();
+    const adjustment = 0.08;
+    if (event.key === 'ArrowLeft') adjustCamera(adjustment, 0);
+    else if (event.key === 'ArrowRight') adjustCamera(-adjustment, 0);
+    else if (event.key === 'ArrowUp') adjustCamera(0, -adjustment);
+    else if (event.key === 'ArrowDown') adjustCamera(0, adjustment);
+    else if (event.key.toLowerCase() === 'n' && ['follow', 'driver'].includes(status.mode.id))
+      selectNextFollowVehicle();
+    else if (
+      ['lookup', 'ramp', 'follow', 'driver'].includes(status.mode.id) &&
+      ['l', 'r'].includes(event.key.toLowerCase())
+    )
+      selectCameraSection(event.key.toUpperCase() as 'L' | 'R');
+    else if (/^[1-8]$/.test(event.key))
+      selectSpectatorMode(SPECTATOR_MODES[Number(event.key) - 1].id);
+    else return;
+    event.preventDefault();
   });
   onSpectatorChange((status) => render(status, true));
   onSpectatorProgress((progress) => {


### PR DESCRIPTION
## 概要

矢印キーの視点調整、Nの追尾対象変更、L/Rの区間変更、1〜8のモード直接選択を追加します。入力欄やボタンにフォーカス中は発火しません。

## Stack

- base: `issue-134-fixed-section`
- head: `issue-132-camera-keyboard`
- #141 の上に積層する最上層です。

Closes #132
Closes #130