### PR TITLE
カメラモードを4階層（オート／定点／ドローン／追跡）に再編する

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
       <button type="button" data-section="R">R</button>
       <button id="nextVehicleBtn" type="button">次の車</button>
     </div>
+    <div id="variationBar" class="camera-operation-bar" hidden></div>
 
     <!-- パネル配置レイヤー（コントロールパネルと情報パネルの位置関係をまとめて決める） -->
     <div id="panelLayer">

--- a/index.html
+++ b/index.html
@@ -71,26 +71,29 @@
       <i data-lucide="sun"></i>
     </button>
 
-    <!-- カメラモード切替（右上・丸ボタン。押すたびに視点が循環する） -->
-    <button
-      id="spectatorBtn"
-      title="カメラ: オートモード(押して切替)"
-      aria-label="カメラ: オートモード(押して切替)"
-      aria-expanded="false"
-      aria-controls="spectatorMenu"
-    >
-      <i data-lucide="clapperboard"></i>
-    </button>
-    <div id="spectatorLabel"></div>
-    <div id="spectatorMenu" aria-label="カメラモード"></div>
-    <button id="cameraResetBtn" type="button" hidden>視点を戻す</button>
-    <div id="cameraPanHint" hidden>Shift+ドラッグ／2本指で道路沿いに移動</div>
-    <div id="vehicleCameraBar" class="camera-operation-bar" hidden>
-      <button type="button" data-section="L">L</button>
-      <button type="button" data-section="R">R</button>
-      <button id="nextVehicleBtn" type="button">次の車</button>
+    <!-- カメラ操作（右上・丸ボタンと、その視点でだけ使う詳細操作をひとまとまりに置く。
+         モード切替と詳細操作が離れていると視線と指の往復が生じるため縦に隣接させる） -->
+    <div id="cameraControls">
+      <button
+        id="spectatorBtn"
+        title="カメラ: オートモード(押して切替)"
+        aria-label="カメラ: オートモード(押して切替)"
+        aria-expanded="false"
+        aria-controls="spectatorMenu"
+      >
+        <i data-lucide="clapperboard"></i>
+      </button>
+      <div id="spectatorLabel"></div>
+      <div id="spectatorMenu" class="sign" aria-label="カメラモード"></div>
+      <div id="variationBar" class="sign camera-operation-bar" hidden></div>
+      <div id="vehicleCameraBar" class="sign camera-operation-bar" hidden>
+        <button type="button" data-section="L">L</button>
+        <button type="button" data-section="R">R</button>
+        <button id="nextVehicleBtn" type="button">次の車</button>
+      </div>
+      <button id="cameraResetBtn" type="button" hidden>視点を戻す</button>
+      <div id="cameraPanHint" class="sign" hidden>Shift+ドラッグ／2本指で道路沿いに移動</div>
     </div>
-    <div id="variationBar" class="camera-operation-bar" hidden></div>
 
     <!-- パネル配置レイヤー（コントロールパネルと情報パネルの位置関係をまとめて決める） -->
     <div id="panelLayer">

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -454,32 +454,40 @@ function setMode(index: number): void {
   notify();
 }
 
-// 現在モードの指定したバリエーションを活性化する
+// 現在モードの指定したバリエーションを活性化する。
+// 切り替えの手順はプリセット切り替えと同じなので switchPreset に委ねる
+// (追尾対象を引き継ぐかどうかの判断も1箇所にまとまる)
 function activateVariation(variationIndex: number): void {
   const mode = CAMERA_MODES[spectator.modeIndex];
   const variation = mode.variations[variationIndex];
   if (!variation) return;
-  const presetIndex = SPECTATOR_PRESETS.findIndex((p) => p.id === variation.presetId);
+  const presetIndex = SPECTATOR_PRESETS.findIndex((preset) => preset.id === variation.presetId);
   if (presetIndex < 0) return;
-  spectator.presetIndex = presetIndex;
-  spectator.presetTime = 0;
-  spectator.cycleTimer = 0;
-  progressListener?.(0);
-  beginTransition();
-  resetCameraAdjustment();
-  followVehicle = null;
-  followChanged = false;
+  spectator.variationIndex = variationIndex;
+  switchPreset(presetIndex);
+}
+
+// 車に固定する視点(三人称の追尾と一人称のドライバー)
+function isVehiclePreset(id: SpectatorPresetId): boolean {
+  return id === 'follow' || id === 'driver';
 }
 
 // 表示するプリセットを切り替える。今の姿勢から新しい姿勢へ補間を始める
 function switchPreset(index: number): void {
+  const previousId = SPECTATOR_PRESETS[spectator.presetIndex].id;
   spectator.presetIndex = (index + SPECTATOR_PRESETS.length) % SPECTATOR_PRESETS.length;
+  const nextId = SPECTATOR_PRESETS[spectator.presetIndex].id;
   spectator.presetTime = 0;
   spectator.cycleTimer = 0;
   progressListener?.(0);
   beginTransition();
   resetCameraAdjustment();
-  followVehicle = null; // プリセットが変わったら追尾対象は選び直す
+  // 追尾↔ドライバーの行き来では同じ車を見続ける。
+  // 「同じ車を三人称と一人称で見比べる」のが自然な操作で、
+  // ここで選び直すと視点だけでなく対象車まで変わってしまう
+  if (!(isVehiclePreset(previousId) && isVehiclePreset(nextId))) {
+    followVehicle = null; // それ以外はプリセットが変わったら追尾対象を選び直す
+  }
   followChanged = false;
 }
 
@@ -499,6 +507,7 @@ export function selectVariation(index: number): void {
   const mode = CAMERA_MODES[spectator.modeIndex];
   if (mode.variations.length === 0) return;
   activateVariation((index + mode.variations.length) % mode.variations.length);
+  notify(); // 操作バーの選択表示を更新する
 }
 
 // 現在のカメラ位置と注視点から軌道パラメータ(theta/phi/radius)を逆算する。

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -56,6 +56,69 @@ export type SpectatorPresetId =
   | 'driver'
   | 'ramp';
 
+export type CameraModeId = 'auto' | 'fixed' | 'drone' | 'tracking';
+
+export interface CameraVariation {
+  id: string;
+  label: string;
+  icon: string;
+  presetId: SpectatorPresetId;
+}
+
+export interface CameraModeDef {
+  id: CameraModeId;
+  label: string;
+  icon: string;
+  variations: CameraVariation[];
+  showSectionToggle: boolean;
+  showNextVehicle: boolean;
+}
+
+export const CAMERA_MODES: CameraModeDef[] = [
+  {
+    id: 'auto',
+    label: 'オート',
+    icon: 'repeat',
+    variations: [],
+    showSectionToggle: false,
+    showNextVehicle: false,
+  },
+  {
+    id: 'fixed',
+    label: '定点',
+    icon: 'map',
+    variations: [
+      { id: 'overhead', label: '俯瞰', icon: 'map', presetId: 'overhead' },
+      { id: 'lookup', label: '見上げ', icon: 'move-up', presetId: 'lookup' },
+      { id: 'ramp', label: '合流', icon: 'merge', presetId: 'ramp' },
+    ],
+    showSectionToggle: true,
+    showNextVehicle: false,
+  },
+  {
+    id: 'drone',
+    label: 'ドローン',
+    icon: 'send',
+    variations: [
+      { id: 'drone', label: 'サークル', icon: 'send', presetId: 'drone' },
+      { id: 'flyby', label: 'フライバイ', icon: 'send', presetId: 'flyby' },
+    ],
+    showSectionToggle: false,
+    showNextVehicle: false,
+  },
+  {
+    id: 'tracking',
+    label: '追跡',
+    icon: 'car-front',
+    variations: [
+      { id: 'follow', label: '三人称', icon: 'car-front', presetId: 'follow' },
+      { id: 'driver', label: '一人称', icon: 'eye', presetId: 'driver' },
+    ],
+    showSectionToggle: true,
+    showNextVehicle: true,
+  },
+];
+
 interface Pose {
   position: THREE.Vector3;
   target: THREE.Vector3;
@@ -67,8 +130,10 @@ interface PresetContext {
 export interface SpectatorPreset {
   id: SpectatorPresetId;
   label: string;
-  icon: string; // lucide アイコン名
-  compute: (pose: Pose, ctx: PresetContext) => void; // pose を書き換える（確保を避ける）
+  icon: string;
+  mode: CameraModeId;
+  variationId: string;
+  compute: (pose: Pose, ctx: PresetContext) => void;
 }
 
 /* ---- 車に固定する視点(追尾・ドライバー)が追う車 ----
@@ -115,6 +180,8 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'drone',
     label: 'ドローン',
     icon: 'send',
+    mode: 'drone',
+    variationId: 'drone',
     // ゆっくり旋回しながら前後にも漂う空撮風の動的視点
     compute(pose, { time }) {
       const angle = time * 0.12;
@@ -132,6 +199,8 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'overhead',
     label: '俯瞰',
     icon: 'map',
+    mode: 'fixed',
+    variationId: 'overhead',
     // 端末の長辺に道路の進行方向を合わせる。横長(正方形を含む)では横から、
     // 縦長では従来どおり奥側から見下ろし、両区間の流れを比較しやすくする
     compute(pose) {
@@ -147,6 +216,8 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'lookup',
     label: '見上げ',
     icon: 'move-up',
+    mode: 'fixed',
+    variationId: 'lookup',
     // 路肩の地面すれすれから、向かってくる車列を見上げる視点。
     // 車は -Z へ進むので +Z 側(奥)から迫ってきて、目の前を大きく通り過ぎる
     compute(pose) {
@@ -159,6 +230,8 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'follow',
     label: '追尾',
     icon: 'car-front',
+    mode: 'tracking',
+    variationId: 'follow',
     // 特定の車を後方やや上から追う視点(車の全体像が見える)
     compute(pose, { world }) {
       const vehicle = pickFollowVehicle(world);
@@ -172,6 +245,8 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'flyby',
     label: 'フライバイ',
     icon: 'send',
+    mode: 'drone',
+    variationId: 'flyby',
     // 車両とは逆の +Z へ進み、車列と正面からすれ違いながら両区間を映す
     compute(pose, { time }) {
       const flyby = flybyPose(time, CENTER_X);
@@ -183,6 +258,8 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'driver',
     label: 'ドライバー',
     icon: 'eye',
+    mode: 'tracking',
+    variationId: 'driver',
     // 運転席から前方を見る一人称視点。
     // 目線の高さは車種の車高に比例させ(トラックは高く、スポーツカーは低く)、
     // 着座位置は車体中央のわずかに後ろ・右寄り(日本の右ハンドル)に置く。
@@ -201,6 +278,8 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
     id: 'ramp',
     label: '合流',
     icon: 'merge',
+    mode: 'fixed',
+    variationId: 'ramp',
     // 合流ランプ(加速車線)付近を斜め上から捉え、本線への合流を眺める
     compute(pose) {
       const centerX = followSection === 'L' ? L_CENTER_X : R_CENTER_X;
@@ -211,32 +290,28 @@ export const SPECTATOR_PRESETS: SpectatorPreset[] = [
 ];
 
 /* ---- モード一覧 ----
-   トグルボタンを押すたびにこの順で切り替わる。
-   先頭は「マニュアルモード(自分で視点を操作する)」、次が「オートモード」、
-   以降は各プリセットの手動固定。オートモードも1つのモードとして循環に含める */
+    4 モード（オート／定点／ドローン／追跡）の定義。
+    プリセットは CAMERA_MODES に属する variation 経由で参照される。 */
 export interface SpectatorMode {
-  id: 'auto' | SpectatorPresetId;
+  id: CameraModeId;
   label: string;
   icon: string;
 }
-export const SPECTATOR_MODES: SpectatorMode[] = [
-  { id: 'auto', label: 'オートモード', icon: 'repeat' },
-  ...SPECTATOR_PRESETS.map((preset) => ({
-    id: preset.id,
-    label: preset.label,
-    icon: preset.icon,
-  })),
-];
+export const SPECTATOR_MODES: SpectatorMode[] = CAMERA_MODES.map((mode) => ({
+  id: mode.id,
+  label: mode.label,
+  icon: mode.icon,
+}));
 const AUTO_MODE_INDEX = 0;
-const FIRST_PRESET_MODE_INDEX = 1;
 
 const AUTO_CYCLE_INTERVAL = 9; // オートモードでプリセットを切り替える間隔 (s)
 const AUTO_RESUME_DELAY = 3; // 操作終了後に巡回を再開するまでの待機時間 (s)
 const TRANSITION_DURATION = 1.2; // 視点の切り替えにかける時間 (s)
 
 interface SpectatorState {
-  modeIndex: number; // SPECTATOR_MODES の添字
-  presetIndex: number; // 現在表示中のプリセット(オートモード中は時間で進む)
+  modeIndex: number; // CAMERA_MODES の添字
+  variationIndex: number; // 現在のモードのバリエーション添字
+  presetIndex: number; // オートモード中の現在のプリセット
   presetTime: number; // 現プリセットに切り替わってからの経過秒
   cycleTimer: number; // オートモードのプリセット切り替えタイマー
   transitionTime: number; // 視点切り替えの補間経過秒
@@ -251,6 +326,7 @@ interface SpectatorState {
 // マニュアルモードへ移る(モードの存在に気づいてもらうため) (Issue #43)
 const spectator: SpectatorState = {
   modeIndex: AUTO_MODE_INDEX,
+  variationIndex: 0,
   presetIndex: 0,
   presetTime: 0,
   cycleTimer: 0,
@@ -272,14 +348,18 @@ export interface SpectatorStatus {
   enabled: boolean; // カメラが自動で動いている(マニュアルモード以外)
   auto: boolean;
   mode: SpectatorMode; // トグルボタンが示す現在のモード
+  variation: CameraVariation | null; // 選択中のバリエーション(オート時は null)
   adjusted: boolean;
   section: Section;
 }
 export function getSpectatorStatus(): SpectatorStatus {
+  const mode = CAMERA_MODES[spectator.modeIndex];
+  const variation = mode.variations[spectator.variationIndex] ?? null;
   return {
     enabled: true,
     auto: spectator.modeIndex === AUTO_MODE_INDEX,
-    mode: SPECTATOR_MODES[spectator.modeIndex],
+    mode,
+    variation,
     adjusted:
       spectator.yawOffset !== 0 ||
       spectator.pitchOffset !== 0 ||
@@ -326,13 +406,14 @@ export function resetCameraAdjustment(): void {
   notify();
 }
 
-function isFixedPreset(): boolean {
-  return ['overhead', 'lookup', 'ramp'].includes(getSpectatorStatus().mode.id);
+/** 現在のモードが定点（パン操作対象）か */
+function isFixedMode(): boolean {
+  return CAMERA_MODES[spectator.modeIndex].id === 'fixed';
 }
 
 /** 固定視点を道路沿いに移動する。追尾・動的視点では安全に無視する */
 function panFixedCamera(deltaZ: number): void {
-  if (!isFixedPreset()) return;
+  if (!isFixedMode()) return;
   spectator.panOffsetZ = clamp(spectator.panOffsetZ + deltaZ, -180, 180);
   notify();
 }
@@ -360,6 +441,36 @@ export function selectNextFollowVehicle(): void {
   resetCameraAdjustment();
 }
 
+// 指定したモードに切り替える。バリエーションは先頭にリセットし、
+// オートモードならプリセット 0 から始める
+function setMode(index: number): void {
+  spectator.modeIndex = (index + CAMERA_MODES.length) % CAMERA_MODES.length;
+  spectator.variationIndex = 0;
+  if (spectator.modeIndex === AUTO_MODE_INDEX) {
+    switchPreset(0);
+  } else {
+    activateVariation(0);
+  }
+  notify();
+}
+
+// 現在モードの指定したバリエーションを活性化する
+function activateVariation(variationIndex: number): void {
+  const mode = CAMERA_MODES[spectator.modeIndex];
+  const variation = mode.variations[variationIndex];
+  if (!variation) return;
+  const presetIndex = SPECTATOR_PRESETS.findIndex((p) => p.id === variation.presetId);
+  if (presetIndex < 0) return;
+  spectator.presetIndex = presetIndex;
+  spectator.presetTime = 0;
+  spectator.cycleTimer = 0;
+  progressListener?.(0);
+  beginTransition();
+  resetCameraAdjustment();
+  followVehicle = null;
+  followChanged = false;
+}
+
 // 表示するプリセットを切り替える。今の姿勢から新しい姿勢へ補間を始める
 function switchPreset(index: number): void {
   spectator.presetIndex = (index + SPECTATOR_PRESETS.length) % SPECTATOR_PRESETS.length;
@@ -372,6 +483,24 @@ function switchPreset(index: number): void {
   followChanged = false;
 }
 
+/** トグルボタン: マニュアル → オート → 各モード → マニュアル… と1つ進める */
+export function cycleSpectatorMode(): void {
+  setMode(spectator.modeIndex + 1);
+}
+
+/** メニューやショートカットから目的のモードへ直接切り替える */
+export function selectSpectatorMode(id: CameraModeId): void {
+  const index = CAMERA_MODES.findIndex((mode) => mode.id === id);
+  if (index >= 0) setMode(index);
+}
+
+/** 現在モードのバリエーションを切り替える */
+export function selectVariation(index: number): void {
+  const mode = CAMERA_MODES[spectator.modeIndex];
+  if (mode.variations.length === 0) return;
+  activateVariation((index + mode.variations.length) % mode.variations.length);
+}
+
 // 現在のカメラ位置と注視点から軌道パラメータ(theta/phi/radius)を逆算する。
 // マニュアルモードへ戻すときに、今の見え方をそのまま引き継ぐため
 function syncOrbitFromCamera(): void {
@@ -380,28 +509,6 @@ function syncOrbitFromCamera(): void {
   cameraController.radius = radius;
   cameraController.phi = clamp(Math.acos(clamp(relative.y / radius, -1, 1)), 0.25, 1.45);
   cameraController.theta = Math.atan2(relative.x, relative.z);
-}
-
-function setMode(index: number): void {
-  spectator.modeIndex = (index + SPECTATOR_MODES.length) % SPECTATOR_MODES.length;
-  if (spectator.modeIndex === AUTO_MODE_INDEX) {
-    // オートモードは先頭のプリセットから始める
-    switchPreset(0);
-  } else {
-    switchPreset(spectator.modeIndex - FIRST_PRESET_MODE_INDEX);
-  }
-  notify();
-}
-
-/** トグルボタン: マニュアル → オート → 各プリセット → マニュアル… と1つ進める */
-export function cycleSpectatorMode(): void {
-  setMode(spectator.modeIndex + 1);
-}
-
-/** メニューやショートカットから目的のモードへ直接切り替える */
-export function selectSpectatorMode(id: SpectatorMode['id']): void {
-  const index = SPECTATOR_MODES.findIndex((mode) => mode.id === id);
-  if (index >= 0) setMode(index);
 }
 
 /** マニュアルモードへ戻す(画面のタップ・ドラッグ・ホイール操作から呼ばれる) */
@@ -425,7 +532,7 @@ function updateSpectator(world: World, deltaTime: number): void {
     time: spectator.presetTime,
     world,
   });
-  if (isFixedPreset()) {
+  if (isFixedMode()) {
     goalPose.position.z += spectator.panOffsetZ;
     goalPose.target.z += spectator.panOffsetZ;
   }
@@ -501,7 +608,7 @@ export function setupCameraControls(): void {
     // ドラッグでもマニュアルモードへ戻す(タップを伴わないペン等の操作に備える)。
     // enterManualMode() の中で今の見え方が軌道パラメータへ引き継がれる
     if (pointers.size === 1) {
-      if (e.shiftKey && isFixedPreset()) {
+      if (e.shiftKey && isFixedMode()) {
         panFixedCamera(deltaY * 0.7);
       } else {
         spectator.yawOffset -= deltaX * 0.005;

--- a/src/style.css
+++ b/src/style.css
@@ -30,7 +30,9 @@ input {
 /* 白地のボタンは外側が緑のパネルなので、リングをボタンの内側に描いて濃い緑で示す */
 #resetBtn:focus-visible,
 #paramsBtn:focus-visible,
-#paramApply:focus-visible {
+#paramApply:focus-visible,
+#cameraResetBtn:focus-visible,
+.camera-operation-bar button:focus-visible {
   outline-color: #05613b;
   outline-offset: -4px;
 }
@@ -520,15 +522,31 @@ body.night #nightBtn {
   }
 }
 
-/* ---- カメラモード切替(右上・カラーモード切替の下) ----
-   専用パネルではなく丸ボタン1つに集約しているため、
-   画面が狭くても他のパネル(スコア比較・コントロール)と干渉しない */
-#spectatorBtn {
-  --auto-cycle-progress: 0;
+/* ---- カメラ操作(右上・カラーモード切替の下) ----
+   モード切替の丸ボタンと、その視点でだけ意味を持つ詳細操作(区間切替・次の車・
+   視点を戻す・操作ヒント)を1つの縦並びにまとめる。
+   詳細操作を画面の反対側に置くと切替のたびに視線と指が往復するため、
+   出どころのボタンの真下に生やす。位置指定はこのラッパー1箇所に集約し、
+   画面サイズごとの調整もここだけで済ませる */
+#cameraControls {
   position: fixed;
   top: 78px;
   right: 14px;
   z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  /* ラッパーの余白でカメラのドラッグ操作を奪わないよう、当たり判定は子だけに持たせる */
+  pointer-events: none;
+}
+#cameraControls > * {
+  pointer-events: auto;
+}
+#spectatorBtn {
+  --auto-cycle-progress: 0;
+  position: relative;
+  flex: none;
   width: 56px;
   height: 56px;
   padding: 0;
@@ -594,12 +612,10 @@ body.night #nightBtn {
     inset 0 1px 0 rgba(255, 255, 255, 0.35),
     0 0 20px rgba(255, 213, 74, 0.55);
 }
-/* 現在のモード名。モード変更時だけボタンの下に右揃えで出す */
+/* 現在のモード名。モード変更時だけボタンの下に出す。
+   消えている間も場所を空けたままにして(不透明度だけを変える)、
+   下に続く詳細操作が出入りのたびに上下しないようにする */
 #spectatorLabel {
-  position: fixed;
-  top: 138px;
-  right: 14px;
-  z-index: 30;
   max-width: 45vw;
   padding: 3px 10px;
   border-radius: 999px;
@@ -621,18 +637,16 @@ body.night #nightBtn {
   opacity: 1;
   transform: translateY(0);
 }
+/* モード一覧はボタンの左隣に開く(下に開くと詳細操作を覆ってしまう)。
+   見た目は他のパネルと同じ案内標識風(.sign)に揃える */
 #spectatorMenu {
   display: none;
-  position: fixed;
-  top: 78px;
-  right: 78px;
+  position: absolute;
+  top: 0;
+  right: calc(100% + 8px);
   z-index: 31;
   width: 210px;
-  padding: 10px;
-  border-radius: 12px;
-  color: #fff;
-  background: rgba(3, 38, 27, 0.94);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  padding: 8px;
 }
 #spectatorMenu.open {
   display: flex;
@@ -649,111 +663,104 @@ body.night #nightBtn {
   border-radius: 8px;
   color: inherit;
   background: transparent;
-  text-align: left;
   font: inherit;
+  font-size: 13px;
+  font-weight: 800;
+  text-align: left;
   cursor: pointer;
 }
-#spectatorMenu button:hover,
+#spectatorMenu button:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+/* 選択中は他のパネルと同じ強調色(黄)で塗る */
 #spectatorMenu button.selected {
-  background: rgba(255, 213, 74, 0.2);
+  color: #05613b;
+  background: #ffd54a;
 }
 #spectatorMenu .lucide {
   width: 18px;
   height: 18px;
 }
-#variationBar {
-  position: fixed;
-  right: 14px;
-  bottom: 52px;
-  z-index: 30;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border-radius: 10px;
-  background: rgba(3, 38, 27, 0.9);
-}
+/* バリエーション切替(定点なら俯瞰/見上げ/合流、追跡なら三人称/一人称)も
+   同じ操作バーとして扱い、モード切替ボタンの真下に並べる */
 #variationBar button {
   display: flex;
   align-items: center;
   gap: 5px;
-  padding: 5px 9px;
-  border: 0;
-  border-radius: 7px;
-  color: inherit;
-  background: transparent;
-  font: inherit;
-  cursor: pointer;
-}
-#variationBar button:hover,
-#variationBar button.selected {
-  background: rgba(255, 213, 74, 0.2);
 }
 #variationBar .lucide {
   width: 16px;
   height: 16px;
 }
-#cameraResetBtn {
-  position: fixed;
-  top: 148px;
-  right: 14px;
-  z-index: 30;
+/* 詳細操作のボタンは、コントロールパネルの白ボタン(#resetBtn)と同じ質感に揃える */
+#cameraResetBtn,
+.camera-operation-bar button {
   padding: 7px 11px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  border-radius: 999px;
-  color: #fff;
-  background: rgba(3, 38, 27, 0.88);
+  border: none;
+  border-radius: 9px;
+  color: #05613b;
+  background: #fff;
+  font-size: 12.5px;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 3px 0 #c8d6cd;
+  transition:
+    transform 0.08s,
+    box-shadow 0.08s;
+}
+#cameraResetBtn:active,
+.camera-operation-bar button:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #c8d6cd;
 }
 #cameraPanHint {
-  position: fixed;
-  right: 14px;
-  bottom: 18px;
-  z-index: 29;
+  max-width: 210px;
   padding: 5px 9px;
-  border-radius: 7px;
-  color: #fff;
-  background: rgba(3, 38, 27, 0.75);
+  border-width: 2px;
+  border-radius: 9px;
   font-size: 11px;
+  font-weight: 700;
+  line-height: 1.5;
+  text-align: right;
   pointer-events: none;
 }
 .camera-operation-bar {
-  position: fixed;
-  right: 14px;
-  bottom: 18px;
-  z-index: 30;
   display: flex;
-  gap: 5px;
+  gap: 6px;
   padding: 6px;
-  border-radius: 10px;
-  background: rgba(3, 38, 27, 0.9);
+  border-width: 2px;
+  border-radius: 12px;
 }
 .camera-operation-bar[hidden] {
   display: none;
 }
-.camera-operation-bar button {
-  padding: 7px 10px;
-  border: 0;
-  border-radius: 7px;
-}
+/* 選択中の区間は、案内標識の強調色(黄)で塗って現在地を示す */
 .camera-operation-bar button.selected {
-  color: #173b20;
+  color: #05613b;
   background: #ffd54a;
+  box-shadow: 0 3px 0 #c39a13;
+}
+.camera-operation-bar button.selected:active {
+  box-shadow: 0 1px 0 #c39a13;
 }
 @media (max-width: 700px) {
+  #cameraControls {
+    top: 68px;
+    right: 10px;
+  }
   #spectatorBtn {
     width: 50px;
     height: 50px;
-    top: 68px;
-    right: 10px;
   }
   #spectatorBtn .lucide {
     width: 23px;
     height: 23px;
   }
   #spectatorLabel {
-    top: 122px;
-    right: 10px;
     font-size: 10.5px;
+  }
+  #cameraPanHint {
+    max-width: 44vw;
   }
 }
 /* 横持ちで高さが足りない時は丸ボタンを小さく詰めて縦の占有を減らす */
@@ -768,19 +775,20 @@ body.night #nightBtn {
     width: 21px;
     height: 21px;
   }
+  #cameraControls {
+    top: 60px;
+    right: 10px;
+    gap: 6px;
+  }
   #spectatorBtn {
     width: 44px;
     height: 44px;
-    top: 60px;
-    right: 10px;
   }
   #spectatorBtn .lucide {
     width: 21px;
     height: 21px;
   }
   #spectatorLabel {
-    top: 108px;
-    right: 10px;
     font-size: 10px;
     padding: 2px 8px;
   }

--- a/src/style.css
+++ b/src/style.css
@@ -635,14 +635,11 @@ body.night #nightBtn {
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
 }
 #spectatorMenu.open {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
-.camera-menu-heading {
-  padding: 5px 8px;
-  font-size: 11px;
-  opacity: 0.7;
-}
-.camera-menu-group button {
+#spectatorMenu button {
   display: flex;
   align-items: center;
   gap: 9px;
@@ -653,14 +650,48 @@ body.night #nightBtn {
   color: inherit;
   background: transparent;
   text-align: left;
+  font: inherit;
+  cursor: pointer;
 }
-.camera-menu-group button:hover,
-.camera-menu-group button.selected {
+#spectatorMenu button:hover,
+#spectatorMenu button.selected {
   background: rgba(255, 213, 74, 0.2);
 }
-.camera-menu-group .lucide {
+#spectatorMenu .lucide {
   width: 18px;
   height: 18px;
+}
+#variationBar {
+  position: fixed;
+  right: 14px;
+  bottom: 52px;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 10px;
+  background: rgba(3, 38, 27, 0.9);
+}
+#variationBar button {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 9px;
+  border: 0;
+  border-radius: 7px;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+#variationBar button:hover,
+#variationBar button.selected {
+  background: rgba(255, 213, 74, 0.2);
+}
+#variationBar .lucide {
+  width: 16px;
+  height: 16px;
 }
 #cameraResetBtn {
   position: fixed;

--- a/src/ui/spectator.ts
+++ b/src/ui/spectator.ts
@@ -1,10 +1,9 @@
 /* ================= カメラモード切替(右上の丸ボタン) =================
-   専用パネルを置くと画面が狭いときに他のパネルと干渉し、項目も増えて煩雑になる。
-   そこでカラーモード切替と同じ「押すたびに切り替わる丸ボタン」1つに集約し、
-   マニュアル → オート → 各プリセット → マニュアル… と循環させる。
-   カメラ状態そのものは render/camera.ts が持ち、ここは操作と表示だけを行う。 */
+    4 モード（オート／定点／ドローン／追跡）のメニューと、
+    選択中モードのバリエーション・区間を操作バーで切り替える。
+    カメラ状態そのものは render/camera.ts が持ち、ここは操作と表示だけを行う。 */
 import {
-  SPECTATOR_MODES,
+  CAMERA_MODES,
   adjustCamera,
   getSpectatorStatus,
   onSpectatorChange,
@@ -13,11 +12,16 @@ import {
   selectCameraSection,
   selectNextFollowVehicle,
   selectSpectatorMode,
+  selectVariation,
 } from '../render/camera';
 import type { SpectatorStatus } from '../render/camera';
 import { icon, renderIcons } from './icons';
 
 const MODE_LABEL_DURATION_MS = 3000;
+
+function isFixedMode(modeId: string): boolean {
+  return modeId === 'fixed';
+}
 
 export function setupSpectator(): void {
   const button = document.getElementById('spectatorBtn')!;
@@ -26,10 +30,10 @@ export function setupSpectator(): void {
   const resetButton = document.getElementById('cameraResetBtn')!;
   const panHint = document.getElementById('cameraPanHint')!;
   const vehicleBar = document.getElementById('vehicleCameraBar')!;
+  const variationContainer = document.getElementById('variationBar')!;
   let labelTimer: ReturnType<typeof setTimeout> | undefined;
 
   function render(status: SpectatorStatus, showLabel: boolean): void {
-    // アイコンは「今どのモードか」を表す
     button.innerHTML = icon(status.mode.icon);
     button.classList.toggle('on', status.enabled);
     button.classList.toggle('auto', status.auto);
@@ -49,32 +53,37 @@ export function setupSpectator(): void {
       item.classList.toggle('selected', item.dataset.cameraMode === status.mode.id);
     });
     resetButton.hidden = !status.adjusted;
-    panHint.hidden = !['overhead', 'lookup', 'ramp'].includes(status.mode.id);
-    vehicleBar.hidden = !['follow', 'driver', 'lookup', 'ramp'].includes(status.mode.id);
-    document.getElementById('nextVehicleBtn')!.hidden = !['follow', 'driver'].includes(
-      status.mode.id,
-    );
+    panHint.hidden = !isFixedMode(status.mode.id);
+    vehicleBar.hidden = !isFixedMode(status.mode.id) && status.mode.id !== 'tracking';
+    document.getElementById('nextVehicleBtn')!.hidden = status.mode.id !== 'tracking';
     vehicleBar.querySelectorAll<HTMLButtonElement>('[data-section]').forEach((item) => {
       item.classList.toggle('selected', item.dataset.section === status.section);
     });
+    renderVariations(status);
   }
 
-  const groups = [
-    ['オート', SPECTATOR_MODES.filter((mode) => mode.id === 'auto')],
-    [
-      '全体を見る',
-      SPECTATOR_MODES.filter((mode) =>
-        ['drone', 'overhead', 'lookup', 'flyby', 'ramp'].includes(mode.id),
-      ),
-    ],
-    ['車から見る', SPECTATOR_MODES.filter((mode) => ['follow', 'driver'].includes(mode.id))],
-  ] as const;
-  menu.innerHTML = groups
-    .map(
-      ([name, modes]) =>
-        `<div class="camera-menu-group"><div class="camera-menu-heading">${name}</div>${modes.map((mode) => `<button type="button" data-camera-mode="${mode.id}">${icon(mode.icon)}<span>${mode.label}</span></button>`).join('')}</div>`,
-    )
-    .join('');
+  function renderVariations(status: SpectatorStatus): void {
+    const mode = CAMERA_MODES.find((m) => m.id === status.mode.id);
+    if (!mode || mode.variations.length === 0) {
+      variationContainer.innerHTML = '';
+      variationContainer.hidden = true;
+      return;
+    }
+    variationContainer.hidden = false;
+    const currentId = status.variation?.id ?? '';
+    variationContainer.innerHTML = mode.variations
+      .map(
+        (v) =>
+          `<button type="button" data-variation="${v.id}" class="${v.id === currentId ? 'selected' : ''}">${icon(v.icon)}<span>${v.label}</span></button>`,
+      )
+      .join('');
+  }
+
+  menu.innerHTML = CAMERA_MODES.map(
+    (mode) =>
+      `<button type="button" data-camera-mode="${mode.id}">${icon(mode.icon)}<span>${mode.label}</span></button>`,
+  ).join('');
+
   button.addEventListener('click', () => {
     const open = menu.classList.toggle('open');
     button.setAttribute('aria-expanded', String(open));
@@ -83,6 +92,16 @@ export function setupSpectator(): void {
     const item = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-camera-mode]');
     if (!item) return;
     selectSpectatorMode(item.dataset.cameraMode as Parameters<typeof selectSpectatorMode>[0]);
+    menu.classList.remove('open');
+    button.setAttribute('aria-expanded', 'false');
+  });
+  variationContainer.addEventListener('click', (event) => {
+    const item = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-variation]');
+    if (!item) return;
+    const mode = CAMERA_MODES.find((m) => m.id === getSpectatorStatus().mode.id);
+    if (!mode) return;
+    const index = mode.variations.findIndex((v) => v.id === item.dataset.variation);
+    if (index >= 0) selectVariation(index);
     menu.classList.remove('open');
     button.setAttribute('aria-expanded', 'false');
   });
@@ -102,16 +121,25 @@ export function setupSpectator(): void {
     else if (event.key === 'ArrowRight') adjustCamera(-adjustment, 0);
     else if (event.key === 'ArrowUp') adjustCamera(0, -adjustment);
     else if (event.key === 'ArrowDown') adjustCamera(0, adjustment);
-    else if (event.key.toLowerCase() === 'n' && ['follow', 'driver'].includes(status.mode.id))
+    else if (event.key.toLowerCase() === 'n' && status.mode.id === 'tracking')
       selectNextFollowVehicle();
-    else if (
-      ['lookup', 'ramp', 'follow', 'driver'].includes(status.mode.id) &&
-      ['l', 'r'].includes(event.key.toLowerCase())
-    )
-      selectCameraSection(event.key.toUpperCase() as 'L' | 'R');
-    else if (/^[1-8]$/.test(event.key))
-      selectSpectatorMode(SPECTATOR_MODES[Number(event.key) - 1].id);
-    else return;
+    else if (isFixedMode(status.mode.id) || status.mode.id === 'tracking') {
+      if (['l', 'r'].includes(event.key.toLowerCase()))
+        selectCameraSection(event.key.toUpperCase() as 'L' | 'R');
+    } else if (/^[1-8]$/.test(event.key)) {
+      const flat = CAMERA_MODES.flatMap((m) =>
+        m.variations.map((v) => ({ modeId: m.id, presetId: v.presetId })),
+      );
+      const entry = flat[Number(event.key) - 1];
+      if (entry) {
+        selectSpectatorMode(entry.modeId);
+        const mode = CAMERA_MODES.find((m) => m.id === entry.modeId);
+        if (mode) {
+          const vi = mode.variations.findIndex((v) => v.presetId === entry.presetId);
+          if (vi >= 0) selectVariation(vi);
+        }
+      }
+    } else return;
     event.preventDefault();
   });
   onSpectatorChange((status) => render(status, true));

--- a/src/ui/spectator.ts
+++ b/src/ui/spectator.ts
@@ -48,7 +48,6 @@ export function setupSpectator(): void {
     const title = 'カメラ: ' + status.mode.label + '(押して切替)';
     button.title = title;
     button.setAttribute('aria-label', title);
-    renderIcons();
     menu.querySelectorAll<HTMLButtonElement>('[data-camera-mode]').forEach((item) => {
       item.classList.toggle('selected', item.dataset.cameraMode === status.mode.id);
     });
@@ -60,6 +59,9 @@ export function setupSpectator(): void {
       item.classList.toggle('selected', item.dataset.section === status.section);
     });
     renderVariations(status);
+    // アイコンの SVG 化は、バリエーションの差し替えまで終えてからまとめて行う
+    // (先に呼ぶと後から挿入したプレースホルダが変換されずアイコンが消える)
+    renderIcons();
   }
 
   function renderVariations(status: SpectatorStatus): void {


### PR DESCRIPTION
#145 対応

カメラモードをフラットな8プリセット＋オートから、4階層の体系に再編します。

## 変更内容

- **4モード体系**: オート / 定点 / ドローン / 追跡
- **バリエーション**: 各モードの下位バリエーションを操作バーで切り替え
  - 定点: 俯瞰 / 見上げ / 合流
  - ドローン: サークル / フライバイ
  - 追跡: 三人称 / 一人称
- **区間切替**: 定点・追跡のみL/R表示、ドローンは非表示
- **データ駆動**: モード定義からバリエーションとUIを決定（べた書き配列を排除）
- **既存8プリセットすべて到達可能**

## 変更ファイル
- src/render/camera.ts - モード/バリエーション型定義追加、CAMERA_MODES導入
- src/ui/spectator.ts - 4モードメニュー＋バリエーション操作バーに再構築
- index.html - variationBar 追加
- src/style.css - メニュー・バリエーションバーのスタイル追加