### PR TITLE
予約回廊への割り込みを接近速度に依らず禁止する (#160)

### DIFF
--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -433,20 +433,27 @@ export class World {
         Math.max(0, certificate.targetPassTime - this.time),
       ),
     );
-    const blocks = (
-      neighbor: { vehicle: Vehicle; distance: number } | null,
-      closingSpeed: number,
-    ) =>
-      neighbor !== null &&
-      lockedOrders.has(neighbor.vehicle.spawnOrder) &&
-      neighbor.distance <=
-        (vehicle.length + neighbor.vehicle.length) / 2 +
-          CONST.MERGE_BODY_CLEARANCE +
-          Math.max(0, closingSpeed) * remaining;
-    return (
-      blocks(nearestAhead, vehicle.speed - (nearestAhead?.vehicle.speed ?? vehicle.speed)) ||
-      blocks(nearestBehind, (nearestBehind?.vehicle.speed ?? vehicle.speed) - vehicle.speed)
-    );
+    const clearance = (neighbor: { vehicle: Vehicle }) =>
+      (vehicle.length + neighbor.vehicle.length) / 2 + CONST.MERGE_BODY_CLEARANCE;
+    // 後方が locked member の場合（= locked member の前方への割り込み）。
+    // Issue #160: 以前はその瞬間の接近速度で距離を外挿していたため
+    // 「割り込んだ車がその後減速しない」ことを暗黙の前提にしていた。前提が崩れても
+    // member は運動が固定されていて追従で吸収できず、実際に貫通し得る。
+    // そこで割り込む側の将来の挙動を一切前提にせず、closure が生きている間に
+    // member が掃きうる区間（残り時間 × member の速度）への割り込みを一律に禁止する。
+    const blocksBehind =
+      nearestBehind !== null &&
+      lockedOrders.has(nearestBehind.vehicle.spawnOrder) &&
+      nearestBehind.distance <= clearance(nearestBehind) + nearestBehind.vehicle.speed * remaining;
+    // 前方が locked member の場合（= locked member の後方への割り込み）は、
+    // 割り込む側が追従モデルで自ら減速できるため上記の穴は生じない。従来判定のまま。
+    const blocksAhead =
+      nearestAhead !== null &&
+      lockedOrders.has(nearestAhead.vehicle.spawnOrder) &&
+      nearestAhead.distance <=
+        clearance(nearestAhead) +
+          Math.max(0, vehicle.speed - nearestAhead.vehicle.speed) * remaining;
+    return blocksAhead || blocksBehind;
   }
 
   private certificateLocks(section: Section, certificate: MergeCertificate): string[] {

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -456,6 +456,25 @@ export class World {
     return blocksAhead || blocksBehind;
   }
 
+  /**
+   * lane 2 (変更中の進入も含む) で member の直前にいる車を返す。
+   * closure を組む buildMergeDependencyClosure と同じ集合・同じ距離定義を使う。
+   */
+  private nearestLaneTwoAhead(
+    snapshot: WorldSnapshot,
+    section: Section,
+    member: VehicleSnapshot,
+  ): Readonly<{ vehicle: VehicleSnapshot; distance: number }> | null {
+    let nearest: { vehicle: VehicleSnapshot; distance: number } | null = null;
+    for (const candidate of snapshot.lane2BySection[section]) {
+      if (candidate.order === member.order) continue;
+      const distance = (((member.z - candidate.z) % WRAP_LENGTH) + WRAP_LENGTH) % WRAP_LENGTH;
+      if (distance <= 0.001) continue;
+      if (!nearest || distance < nearest.distance) nearest = { vehicle: candidate, distance };
+    }
+    return nearest;
+  }
+
   private certificateLocks(section: Section, certificate: MergeCertificate): string[] {
     return certificate.closure.orders.map((order) => this.entryLockKey(section, order));
   }
@@ -575,6 +594,22 @@ export class World {
         ? `${order}:${vehicle.lane}@${vehicle.z.toFixed(3)}/${vehicle.speed.toFixed(3)}`
         : `${order}:missing`;
     });
+    // role だけでなく、member の直前にいる closure 外の車 (割り込み車) も出す (Issue #160)。
+    // 回廊が壊れる原因が role 同士の詰まりなのか第三者の割り込みなのかを、
+    // 例外メッセージだけで切り分けられるようにする。
+    const roleSet = new Set(roleOrders);
+    const intruders: string[] = [];
+    const rampSnapshot = certificate ? snapshot.byOrder.get(certificate.rampOrder) : undefined;
+    if (certificate && rampSnapshot) {
+      for (const order of certificate.closure.orders) {
+        const member = snapshot.byOrder.get(order);
+        if (!member) continue;
+        const ahead = this.nearestLaneTwoAhead(snapshot, rampSnapshot.section, member);
+        if (!ahead || roleSet.has(ahead.vehicle.order)) continue;
+        const bodyGap = ahead.distance - (member.length + ahead.vehicle.length) / 2;
+        intruders.push(`${order}<-${ahead.vehicle.order}@${bodyGap.toFixed(3)}`);
+      }
+    }
     return new Error(
       [
         '合流予約回廊が空:',
@@ -588,6 +623,7 @@ export class World {
         `dt=${deltaTime}`,
         `envelope=[${plan.envelope?.min},${plan.envelope?.max}]`,
         `roles=[${roles.join(',')}]`,
+        `intruders=[${intruders.join(',')}]`,
         `reason=${reason}`,
       ].join(' '),
     );
@@ -628,6 +664,7 @@ export class World {
       const rampMotion = motions.get(certificate.rampOrder);
       if (!ramp || !rampMotion)
         throw this.corridorError(directive.plan, snapshot, deltaTime, 'ランプ運動なし');
+      const roleOrders = new Set([certificate.rampOrder, ...certificate.closure.orders]);
       const changing = rampMotion.laneChangeProgress !== null;
       const nextProgress = rampMotion.laneChangeProgress ?? ramp.laneChange.progress;
       const nextRampZ = rampMotion.nextZ;
@@ -691,6 +728,32 @@ export class World {
             snapshot,
             deltaTime,
             `closure車体間隔=${bodyGap}:${edge.followerOrder}->${edge.aheadOrder}`,
+          );
+      }
+      // closure の外にいる車 (割り込み車) も検証対象に含める (Issue #160)。
+      // 固定運動は割り込み車に反応できないので、role 同士だけを見ていては
+      // 貫通を検出できなかった。割り込み自体は blocksReservedLaneChange が
+      // 一律に禁止しているので、ここまで来た回廊には「期限まで到達し得ない
+      // 直前車」しか残らないはずである。この検査はその backstop であり、
+      // 通常の実行では発火しない。
+      // 割り込み車の次位置は未確定だが前進しかしないので、現在位置で評価すれば
+      // 実際の車間を下回ることはなく、判定は保守側に倒れる。
+      for (const order of certificate.closure.orders) {
+        const member = snapshots.get(order);
+        const memberMotion = motions.get(order);
+        if (!member || !memberMotion)
+          throw this.corridorError(directive.plan, snapshot, deltaTime, `closure運動なし:${order}`);
+        const ahead = this.nearestLaneTwoAhead(snapshot, ramp.section, member);
+        if (!ahead || roleOrders.has(ahead.vehicle.order)) continue;
+        const centerDistance =
+          (((memberMotion.nextZ - ahead.vehicle.z) % WRAP_LENGTH) + WRAP_LENGTH) % WRAP_LENGTH;
+        const bodyGap = centerDistance - (member.length + ahead.vehicle.length) / 2;
+        if (bodyGap < 0)
+          throw this.corridorError(
+            directive.plan,
+            snapshot,
+            deltaTime,
+            `割り込み車体間隔=${bodyGap}:${order}<-${ahead.vehicle.order}`,
           );
       }
     }

--- a/traffic-simulation.test.ts
+++ b/traffic-simulation.test.ts
@@ -3738,3 +3738,69 @@ describe('追尾カメラの周回境界 (Issue #127)', () => {
     expect(cameraWrapOffset(407, -407)).toBe(-WRAP_LENGTH);
   });
 });
+
+describe('予約回廊への割り込み禁止 (Issue #160)', () => {
+  /**
+   * ランプ車 1 台と lane 2 の縦列で closure を成立させた世界を作る。
+   * 返り値の member は closure member（運動が固定され追従で反応できない車）。
+   *
+   * ここでの検証は blocksReservedLaneChange() の直接呼び出しだけで完結する。
+   * 車線変更中の danger 再判定（事後キャンセル）はこの経路を通らないため、
+   * 「割り込みを開始させない」という証明側の性質だけを切り出して検査できる。
+   */
+  function corridorWorld(): { world: World; member: Vehicle; remaining: number } {
+    const world = new World({ rng: () => 0.5, spawnInterval: 1e9 });
+    const ramp = new Vehicle(world, 'L', 3, CONST.RAMP_Z_TOP, 'Sedan', 24);
+    const front = new Vehicle(world, 'L', 2, 310, 'Sedan', 20);
+    const member = new Vehicle(world, 'L', 2, 285, 'Sedan', 20);
+    const rear = new Vehicle(world, 'L', 2, 375, 'Sedan', 20);
+    const safeBoundary = new Vehicle(world, 'L', 2, 150, 'Sedan', 20);
+    ramp.speed = 24;
+    ramp.waiting = true;
+    for (const vehicle of [front, member, rear, safeBoundary]) vehicle.speed = 20;
+    world.vehicles.push(ramp, front, member, rear, safeBoundary);
+    world.admitWaiting();
+    const certificate = ramp.mergePlan.certificate!;
+    expect(certificate.closure.orders).toContain(member.spawnOrder);
+    return { world, member, remaining: certificate.targetPassTime - world.time };
+  }
+
+  /** member の 32.9m 前方（lane 1）へ割り込もうとする車を置く。 */
+  function placeIntruder(world: World, member: Vehicle, gap: number, speed: number): Vehicle {
+    const intruder = new Vehicle(world, 'L', 1, member.z - gap, 'Sedan', speed);
+    intruder.speed = speed;
+    world.vehicles.push(intruder);
+    world.rebuildSectionIndex();
+    return intruder;
+  }
+
+  test('Issue #160のseed=187相当（距離32.9m・接近速度3.8m/s）の割り込みを拒否する', () => {
+    const { world, member } = corridorWorld();
+    member.speed = 21.8;
+    const intruder = placeIntruder(world, member, 32.9, 18.0);
+
+    expect(world.blocksReservedLaneChange(intruder, 2)).toBe(true);
+  });
+
+  test('接近速度が0以下でもlocked memberの前方への割り込みを拒否する', () => {
+    // 旧実装はその瞬間の接近速度で距離を外挿していたため、割り込む車が
+    // member より速ければ閾値が車体長+クリアランス（約6.6m）まで縮み、
+    // 32.9m 先への割り込みを通していた。割り込んだ車がその後減速すると
+    // member 側は運動が固定されていて吸収できず貫通する。
+    for (const speed of [0, 10, 18, 20, 22, 26, 30]) {
+      const { world, member } = corridorWorld();
+      const intruder = placeIntruder(world, member, 32.9, speed);
+
+      expect(world.blocksReservedLaneChange(intruder, 2)).toBe(true);
+    }
+  });
+
+  test('closure中にmemberが掃く区間の外なら割り込みを許可する', () => {
+    // 一律 true を返しているのではないことの確認。
+    const { world, member, remaining } = corridorWorld();
+    const corridor = CONST.MERGE_BODY_CLEARANCE + member.length + member.speed * remaining + 10;
+    const intruder = placeIntruder(world, member, corridor, 20);
+
+    expect(world.blocksReservedLaneChange(intruder, 2)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 何が問題だったか

合流 transaction は closure member の運動を数秒間 `applyReservedMotion()` で固定する。その間 member は追従モデルで一切反応できない。にもかかわらず、その回廊へ第三者が車線変更で割り込むことを証明が考慮していなかった。

割り込みを防ぐはずの `blocksReservedLaneChange()` は、割り込む車と locked member の**その瞬間の接近速度**で距離を外挿していた。

```
distance <= 車体長/2 + MERGE_BODY_CLEARANCE + max(0, closingSpeed) * remaining
```

これは「割り込んだ車がその後減速しない」ことを暗黙の前提にしており、その前提は保証できない。Issue #160 の実測 (seed=187) では、接近速度 3.6 m/s で「安全」と判定された車 64 がその後 18.2 → 13.7 m/s へ減速し、運動を固定された member 98 が反応できないまま車間 −4.93m の貫通に至る経路が確認されている。

main で貫通が顕在化していないのは証明が効いているからではなく、**車線変更中の danger 再判定による事後キャンセル**という別機構の副作用である (同 seed で cancel が 95 回)。実際にこの再判定を外した #83 のブランチでは同一 seed で貫通が再現した。

## 採用した修正

`blocksReservedLaneChange()` から接近速度の外挿を撤去し、locked member の**前方**への割り込みを一律に禁止する。

境界は「closure が生きている間に member が掃きうる区間」で引く。

```
nearestBehind.distance <= clearance + nearestBehind.vehicle.speed * remaining
```

**なぜ割り込む側の将来挙動を仮定せずに済むのか**: この式に現れる速度は locked member 自身の速度だけである。member の速度は証明で固定されており、予約速度が初速を超えないことは証明の構成から保証されている。したがって「残り時間のうちに member が到達し得る最遠点」は割り込む側の挙動と無関係に上から押さえられる。割り込む側が減速しようが加速しようが、その区間に入っていなければ member は追いつけない。旧実装が壊れたのはまさに割り込む側の未来 (`closingSpeed` が維持されること) を前提にしていたからで、そこを断ち切った。

**member の後方へ入る側 (`blocksAhead`) を従来判定のまま残した理由**: この向きでは前方にいるのが locked member であり、後ろから入る車は**自分自身が追従モデルで減速できる**。固定されて反応できないのは member 側だけなので、member が反応できないことに起因する上記の穴は生じない。ここまで保守的にすると合流付近の車線変更を必要以上に潰し、L/R 双方の挙動を無意味に歪める。

## backstop assertion (案2 からの部分移植)

Issue #160 が挙げていた「`assertTransactionSafety` / `corridorError` の検証も割り込み車を対象に含めていない」点を埋める。

- `nearestLaneTwoAhead()`: closure member の直前にいる lane 2 の車を、closure 構築 (`buildMergeDependencyClosure`) と同じ集合・同じ距離定義で拾う。
- `assertTransactionSafety()`: closure 外の直前車と member の次位置との車体間隔が負なら throw する。割り込み車の次位置は未確定だが前進しかしないので、現在位置で評価すれば実際の車間を下回ることはなく判定は保守側に倒れる。
- `corridorError()`: 同じ情報を `intruders=[...]` として例外メッセージに出す。回廊が壊れた原因が role 同士の詰まりなのか第三者の割り込みなのかを切り分けられるようにする。

移植したのは**検知述語と検証だけ**である。案2 の証明失効機構本体 (`revokeIntrudedReservations` / `revokeMergeCertificate` / 停止線 / Issue #48 監査の緩和など) は一切入れていない。

この assertion は**通常の実行では発火しない**。30 シード × 300 秒の全テストを通して一度も発火せず、30 シードの実測値は割り込み禁止のみを入れた状態と完全に一致した (挙動を変えていないことの裏付けでもある)。

## 30 シードガードの実測

| | main | 本 PR |
|---|---|---|
| L/R スコア平均差 | 3.90 | **4.530** (許容 2〜6) |
| R > L のシード数 | 27/30 | **28/30** (閾値 24) |
| 最悪同一車線車間 | +1.328m | **+0.429m** (貫通なし) |
| 流入の左右偏り | 0.382% | **0.762%** (許容 1%) |

- `pnpm check` pass / `pnpm test` **173 tests pass**
- **`DIFF_TARGET` などのガード期待値、`src/core/constants.ts` の物理定数、`requiredGap` 係数は一切変更していない。**
- 判定は区間非依存で、`section` / `yields` / `camper` / `keepLeft` / `returnTime` を新しい分岐条件に使っていない。

## 残る懸念

- **流入均衡の余裕**: 左右偏り 0.762% は許容 1% の内側だが main の 0.382% より狭い。割り込み禁止が合流付近の車線変更をわずかに抑えることで、ランプ流入のタイミングが両区間で異なる揺らぎ方をしたためと考えられる。判定条件自体は L/R 完全同一なので構造的な交絡ではないが、余裕は減っている。
- **最悪同一車線車間**: +1.328m → +0.429m と薄くなった。貫通はしていない。事象は seed=176 t=273.55 の L 区間 lane 2、低速域 (3.44 / 8.75 m/s) の追従で、合流回廊とは別の場所である。
- **残存経路**: 本修正が止めるのは**新規の車線変更開始**だけである。証明書の発行時点で既に車線変更中だった車が回廊へ入る経路は理屈の上では残る。ただし 30 シード 300 秒で backstop assertion は一度も発火しておらず、実測では顕在化していない。露出した場合は assertion が例外として検出する。

## 案2 (証明の失効) について

もう一方の案である「割り込みを検知したら証明を失効させる」も実装して 30 シードで検証したが、最悪同一車線車間が負に転じること、ランプ車が停止しうるようになり Issue #48 の監査を緩める必要が生じること、それでも残存穴が残ることから採用しなかった。詳細は Issue #160 のコメントに記録した。

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GRpNSjLuR5hZRPAK11Xhu
